### PR TITLE
README 目录概况：统计条替换 sha 展示行

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -20,13 +20,18 @@ Quantitative experience should be described, reproduced, and discussed openly: c
 
 [All organization repositories](https://github.com/orgs/quantskills/repositories) · [navigation repository](https://github.com/quantskills/quantskills) · [registry](https://github.com/quantskills/registry) · [templates](https://github.com/quantskills/skill-template) · [join the community](https://github.com/quantskills/join)
 
-## Live catalog
+## Catalog overview
 
-The following section is generated from the pinned snapshot. Browse the interactive catalog at [www.quantskills.ai](https://www.quantskills.ai/).
+A periodic snapshot of the community's public assets; browse the interactive catalog at [www.quantskills.ai](https://www.quantskills.ai/).
 
 <!-- CATALOG:START -->
 <!-- catalog-snapshot: sha256:ecb9a3d03c6df06f3d5ca7961766ad2927ab3d370ee64e80343c0dd6946567a7 -->
-> Snapshot sha256:ecb9a3d03c6df06f3d5ca7961766ad2927ab3d370ee64e80343c0dd6946567a7. **158** public assets across **10** categories; **1 published** structured endpoint and **157 pending** maintainer interface reviews.
+<table align="center"><tr>
+<td align="center"><strong>158</strong><br><sub>Assets</sub></td>
+<td align="center"><strong>10</strong><br><sub>Categories</sub></td>
+<td align="center"><strong>1</strong><br><sub>Published endpoints</sub></td>
+<td align="center"><strong>2026-08-11</strong><br><sub>Snapshot updated</sub></td>
+</tr></table>
 
 ## Category summary
 - [01 Data APIs & Warehouse](#cat-01) — 7 assets（Data Sources & Connectors / Warehouse & Cache / Market Data Governance / PIT & Data Quality）

--- a/README.md
+++ b/README.md
@@ -20,13 +20,18 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 
 [全部组织仓库](https://github.com/orgs/quantskills/repositories) · [导航仓库](https://github.com/quantskills/quantskills) · [注册表](https://github.com/quantskills/registry) · [模板](https://github.com/quantskills/skill-template) · [加入社区](https://github.com/quantskills/join)
 
-## 动态目录
+## 目录概况
 
-以下内容由固定快照生成；网站入口见 [www.quantskills.ai](https://www.quantskills.ai/)。
+以下是社区公开资产的定期快照；交互式目录见 [www.quantskills.ai](https://www.quantskills.ai/)。
 
 <!-- CATALOG:START -->
 <!-- catalog-snapshot: sha256:ecb9a3d03c6df06f3d5ca7961766ad2927ab3d370ee64e80343c0dd6946567a7 -->
-> 快照 sha256:ecb9a3d03c6df06f3d5ca7961766ad2927ab3d370ee64e80343c0dd6946567a7。**158** 项公开资产，覆盖 **10** 个分类；**1 个已发布**结构化端点，**157 个待维护者接口审核**。
+<table align="center"><tr>
+<td align="center"><strong>158</strong><br><sub>资产</sub></td>
+<td align="center"><strong>10</strong><br><sub>分类</sub></td>
+<td align="center"><strong>1</strong><br><sub>已发布端点</sub></td>
+<td align="center"><strong>2026-08-11</strong><br><sub>快照更新</sub></td>
+</tr></table>
 
 ## 分类总览
 - [01 数据接口与数据仓库](#cat-01) — 7 项资产（数据源与连接器 / 仓库与缓存 / 行情数据治理 / PIT 与数据质量）

--- a/docs/README.en.template.md
+++ b/docs/README.en.template.md
@@ -20,9 +20,9 @@ Quantitative experience should be described, reproduced, and discussed openly: c
 
 [All organization repositories](https://github.com/orgs/quantskills/repositories) · [navigation repository](https://github.com/quantskills/quantskills) · [registry](https://github.com/quantskills/registry) · [templates](https://github.com/quantskills/skill-template) · [join the community](https://github.com/quantskills/join)
 
-## Live catalog
+## Catalog overview
 
-The following section is generated from the pinned snapshot. Browse the interactive catalog at [www.quantskills.ai](https://www.quantskills.ai/).
+A periodic snapshot of the community's public assets; browse the interactive catalog at [www.quantskills.ai](https://www.quantskills.ai/).
 
 <!-- CATALOG:START -->
 <!-- CATALOG:END -->

--- a/docs/README.zh.template.md
+++ b/docs/README.zh.template.md
@@ -20,9 +20,9 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 
 [全部组织仓库](https://github.com/orgs/quantskills/repositories) · [导航仓库](https://github.com/quantskills/quantskills) · [注册表](https://github.com/quantskills/registry) · [模板](https://github.com/quantskills/skill-template) · [加入社区](https://github.com/quantskills/join)
 
-## 动态目录
+## 目录概况
 
-以下内容由固定快照生成；网站入口见 [www.quantskills.ai](https://www.quantskills.ai/)。
+以下是社区公开资产的定期快照；交互式目录见 [www.quantskills.ai](https://www.quantskills.ai/)。
 
 <!-- CATALOG:START -->
 <!-- CATALOG:END -->

--- a/scripts/render-readme.mjs
+++ b/scripts/render-readme.mjs
@@ -29,20 +29,34 @@ function assetRow(asset, language) {
   return `| [${escape(asset.name)}](${asset.url}) | ${escape(language === "en" ? asset.summary_en : asset.summary_zh)} | ${escape(workflow.primary_stage)} | ${escape(endpoint(asset, interface_.inputs))} | ${escape(endpoint(asset, interface_.outputs))} | ${interfaceState(asset, language === "en")} | ${imgCell(asset.name)} |`;
 }
 
+// 快照展示日期：优先 snapshot_id 内嵌时间戳（20260811T051557Z），其次 built_at 元数据
+function snapshotDate(model) {
+  const embedded = String(model.snapshot_id || "").match(/(\d{4})(\d{2})(\d{2})T\d{4}/);
+  if (embedded) return `${embedded[1]}-${embedded[2]}-${embedded[3]}`;
+  const built = String(model.built_at || "").match(/(\d{4})-(\d{2})-(\d{2})/);
+  if (built) return `${built[1]}-${built[2]}-${built[3]}`;
+  return new Date().toISOString().slice(0, 10);
+}
+
 export function renderCatalog(model, language) {
   const english = language === "en";
   const published = model.assets.filter((asset) => asset.interface_status === "published").length;
-  const pending = model.assets.filter((asset) => asset.interface_status === "pending-maintainer").length;
   const labels = english
-    ? { catalog: "Live catalog", summary: "Category summary", workflow: "Workflow map", stages: "stages", assets: "assets", name: "Project", summaryCol: "Bilingual summary", stage: "Primary stage", inputs: "Inputs", outputs: "Outputs", status: "Interface status", shot: "Screenshot", resources: "Infrastructure & community entry points" }
-    : { catalog: "实时目录", summary: "分类总览", workflow: "工作流地图", stages: "个阶段", assets: "项资产", name: "项目", summaryCol: "双语摘要", stage: "主阶段", inputs: "输入", outputs: "输出", status: "接口状态", shot: "截图", resources: "基础设施与社区入口" };
+    ? { catalog: "Live catalog", summary: "Category summary", workflow: "Workflow map", stages: "stages", assets: "assets", name: "Project", summaryCol: "Bilingual summary", stage: "Primary stage", inputs: "Inputs", outputs: "Outputs", status: "Interface status", shot: "Screenshot", lAssets: "Assets", lCats: "Categories", lPub: "Published endpoints", lUpd: "Snapshot updated", resources: "Infrastructure & community entry points" }
+    : { catalog: "实时目录", summary: "分类总览", workflow: "工作流地图", stages: "个阶段", assets: "项资产", name: "项目", summaryCol: "双语摘要", stage: "主阶段", inputs: "输入", outputs: "输出", status: "接口状态", shot: "截图", lAssets: "资产", lCats: "分类", lPub: "已发布端点", lUpd: "快照更新", resources: "基础设施与社区入口" };
   const bySub = {}; // subcategory id -> assets[]（快照 taxonomy 的二级分类归属）
   for (const asset of model.assets) (bySub[asset.catalog?.subcategory] ||= []).push(asset);
   const subNames = (category) =>
     (category.subcategories || []).filter((s) => bySub[s.id]?.length).map((s) => (english ? s.label_en : s.label_zh));
+  const stat = (num, label) => `<td align="center"><strong>${num}</strong><br><sub>${label}</sub></td>`;
   const lines = [
     `<!-- catalog-snapshot: ${model.snapshot_id} -->`,
-    `> ${english ? `Snapshot ${model.snapshot_id}. **${model.assets.length}** public assets across **${model.categories.length}** categories; **${published} published** structured endpoint and **${pending} pending** maintainer interface reviews.` : `快照 ${model.snapshot_id}。**${model.assets.length}** 项公开资产，覆盖 **${model.categories.length}** 个分类；**${published} 个已发布**结构化端点，**${pending} 个待维护者接口审核**。`}`,
+    `<table align="center"><tr>`,
+    stat(model.assets.length, labels.lAssets),
+    stat(model.categories.length, labels.lCats),
+    stat(published, labels.lPub),
+    stat(snapshotDate(model), labels.lUpd),
+    `</tr></table>`,
     "", `## ${labels.summary}`,
     model.categories.map((category) => {
       const total = model.assets.filter((asset) => asset.catalog.category === category.id).length;


### PR DESCRIPTION
在 #3（二级分类、截图列、社群二维码等展示优化，已合并）基础上的收尾改动：

- 「动态目录」改名「目录概况」，导语改为「社区公开资产的定期快照；交互式目录见 www.quantskills.ai」
- sha256 快照指纹行从用户可见文本移除，改为居中统计条：**158 资产 / 10 分类 / 1 已发布端点 / 快照更新 2026-08-11**
- `<!-- catalog-snapshot: ... -->` 注释保留，`verify-readme-sync` 校验不受影响
- `render-readme.mjs` 同步：快照日期从 snapshot_id 内嵌时间戳（`20260811T...`）解析，`built_at` 兜底，后续快照重建自动带正确日期

已用 GitHub markdown API 逐字节核对中英双版渲染输出与 `render-readme.mjs` 一致。