### PR TITLE
Derive site catalog from listed Registry assets

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -25,9 +25,9 @@ Quantitative experience should be described, reproduced, and discussed openly: c
 A periodic snapshot of the community's public assets; browse the interactive catalog at [www.quantskills.ai](https://www.quantskills.ai/).
 
 <!-- CATALOG:START -->
-<!-- catalog-snapshot: sha256:117387f24ed230521243f50541e0d1f8c10cd949848b4ba095c55222ba833c00 -->
+<!-- catalog-snapshot: sha256:276e68899f6db4a7570a1b13cd84231f94987469343002522270686e52e87091 -->
 <table align="center"><tr>
-<td align="center"><strong>156</strong><br><sub>Assets</sub></td>
+<td align="center"><strong>214</strong><br><sub>Assets</sub></td>
 <td align="center"><strong>10</strong><br><sub>Categories</sub></td>
 <td align="center"><strong>1</strong><br><sub>Published endpoints</sub></td>
 <td align="center"><strong>2026-08-29</strong><br><sub>Snapshot updated</sub></td>
@@ -35,14 +35,14 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 
 ## Category summary
 - [01 Data APIs & Warehouse](#cat-01) — 7 assets（Data Sources & Connectors / Warehouse & Cache / Market Data Governance / PIT & Data Quality）
-- [02 Factor R&D Toolbox](#cat-02) — 31 assets（Factor Ideation / Factor Generation / Orthogonalization & Blending / Factor Selection / Factor Evaluation / Factor Pool & Online Serving）
-- [03 Market & Instrument Analysis](#cat-03) — 32 assets（A-Share Equities / HK & US Equities / ETFs, Funds & Indices / Futures & Commodities / Options & Convertible Bonds / Macro & Cross-Asset）
-- [04 Risk Monitoring & Alerts](#cat-04) — 19 assets（Market Regime / Flows & Crowding / Liquidity Risk / Corporate Events / Regulatory Compliance / Portfolio Stress Testing / Automated Alerts）
-- [05 Backtesting & Trading](#cat-05) — 18 assets（Strategies & Signals / Portfolio Construction / Backtesting Engine / Performance Attribution / Transaction Costs / Market Microstructure / Positions & Orders / Paper & Live Execution）
-- [06 Research Models & Replication](#cat-06) — 18 assets（Paper Replication / Strategy Replication / Statistical & ML Models / Investor Research Models / Experiment Registry & Reproducible Research）
-- [07 Research Validation & Quality](#cat-07) — 11 assets（Lookahead & Data Leakage / Survivorship Bias / Walk-Forward & OOS / Signal Stability / Forecast Calibration / Numerical & Model Audit / Workflow Audit）
-- [08 Information Search & Knowledge Analysis](#cat-08) — 6 assets（News & Disclosures / Institutional Research / Daily Review）
-- [09 Quant Agents & Automation](#cat-09) — 8 assets（Research Agent / Monitoring & Risk Agent / Trading Execution Agent / Workflow Orchestration Agent）
+- [02 Factor R&D Toolbox](#cat-02) — 44 assets（Factor Ideation / Factor Generation / Orthogonalization & Blending / Factor Selection / Factor Evaluation / Factor Pool & Online Serving）
+- [03 Market & Instrument Analysis](#cat-03) — 44 assets（A-Share Equities / HK & US Equities / ETFs, Funds & Indices / Futures & Commodities / Options & Convertible Bonds / Macro & Cross-Asset）
+- [04 Risk Monitoring & Alerts](#cat-04) — 22 assets（Market Regime / Flows & Crowding / Liquidity Risk / Corporate Events / Regulatory Compliance / Portfolio Stress Testing / Automated Alerts）
+- [05 Backtesting & Trading](#cat-05) — 25 assets（Strategies & Signals / Portfolio Construction / Backtesting Engine / Performance Attribution / Transaction Costs / Market Microstructure / Positions & Orders / Paper & Live Execution）
+- [06 Research Models & Replication](#cat-06) — 30 assets（Paper Replication / Strategy Replication / Statistical & ML Models / Investor Research Models / Experiment Registry & Reproducible Research）
+- [07 Research Validation & Quality](#cat-07) — 12 assets（Lookahead & Data Leakage / Survivorship Bias / Walk-Forward & OOS / Signal Stability / Forecast Calibration / Numerical & Model Audit / Workflow Audit）
+- [08 Information Search & Knowledge Analysis](#cat-08) — 10 assets（News & Disclosures / Institutional Research / Daily Review）
+- [09 Quant Agents & Automation](#cat-09) — 14 assets（Research Agent / Monitoring & Risk Agent / Trading Execution Agent / Workflow Orchestration Agent）
 - [10 Infrastructure & Templates](#cat-10) — 6 assets（Skill Template / Agent Template / Build & Release Tooling）
 
 ## Workflow map
@@ -87,7 +87,7 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 
 <a id="cat-02"></a>
 <details>
-<summary><strong>02 Factor R&D Toolbox</strong> — 31 assets, 8 with screenshots</summary>
+<summary><strong>02 Factor R&D Toolbox</strong> — 44 assets, 8 with screenshots</summary>
 
 ### Factor Ideation（2）
 
@@ -96,23 +96,33 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 | [skill-factor-idea-generation](https://github.com/quantskills/skill-factor-idea-generation) | Generates candidate factor ideas with economic rationale and risk notes from the default data scope. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-factormad-debate-factor-mining](https://github.com/quantskills/skill-factormad-debate-factor-mining) | Uses a FactorMAD-style multi-agent debate framework for interpretable stock-alpha mining. | factor-generation | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-factormad-debate-factor-mining.png"><img src="assets/skill-factormad-debate-factor-mining.png" width="260"></a> |
 
-### Factor Generation（16）
+### Factor Generation（26）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
 | [skill-a1-lhb-tracking](https://github.com/quantskills/skill-a1-lhb-tracking) | Generates an event-ranking factor from Dragon-Tiger seat history, win rate, payoff, and next-session premium. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-alpha-a06-hotmoney-reversal](https://github.com/quantskills/skill-alpha-a06-hotmoney-reversal) | Computes a hot-money seat cooling and reversal factor from Dragon-Tiger and market data with validation artifacts. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
+| [skill-alpha-a3-streak-leader-relay](https://github.com/quantskills/skill-alpha-a3-streak-leader-relay) | 连板龙头接力（A3）Alpha 因子——从全 A 市场每日 ≥3 板候选池中识别 T+1 接力的事件型 top-N 信号，10 个子因子（个股截面 8 + 大盘情绪 2），权重可用 ICIR + shrinkage 重训，含滚动 IC gate 与 score 加权。研究层面的候选发现器，非交易策略。 | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-alpha-f1-position-change](https://github.com/quantskills/skill-alpha-f1-position-change) | Computes a futures top-20-seat position-change factor and signal from net-position data. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-alpha-f5-member-position-concentration](https://github.com/quantskills/skill-alpha-f5-member-position-concentration) | Computes member-position concentration signals from institutional, hot-money, and northbound net positions. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-alpha-f6-family-position-reverse](https://github.com/quantskills/skill-alpha-f6-family-position-reverse) | Computes a futures family-position reversal signal from seat-position relationships. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-alpha-f8-family-main-divergence](https://github.com/quantskills/skill-alpha-f8-family-main-divergence) | Computes a futures family-versus-main-seat position-divergence factor signal. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
-| [skill-alpha-ncav-graham](https://github.com/quantskills/skill-alpha-ncav-graham) | Computes a Graham NCAV discount factor for A-share deep-value screening and buy-sell-hold signals. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
+| [skill-causal-alpha-discovery](https://github.com/quantskills/skill-causal-alpha-discovery) | Discover causal alpha factors from OHLCV data using causal discovery (PC + LiNGAM + NOTEARS), build Structural Causal Models, construct regime-invariant factor expressions, and validate through backtesting. Produces OHLCV-only alpha factors whose predictive power is grounded in causal mechanisms rather than spurious correlations. Use when an agent needs to discover stable alpha factors that survive regime changes, test whether existing factors are causal or merely correlational, or generate alpha factors with formal invariance guarantees on portable agent platforms such as Claude Code, Codex, or Codex-style skill systems. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-doc-to-alphas](https://github.com/quantskills/skill-doc-to-alphas) | Defines OHLCV alpha-expression formats and validation rules for document-derived factors. | factor-generation | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-doc-to-alphas.png"><img src="assets/skill-doc-to-alphas.png" width="260"></a> |
 | [skill-factor-alpha191-alpha101](https://github.com/quantskills/skill-factor-alpha191-alpha101) | Computes Alpha101 and Alpha191 factors from long-form OHLCV CSV and outputs wide CSV. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
+| [skill-factor-loop-evolve](https://github.com/quantskills/skill-factor-loop-evolve) | Local closed-loop factor research: generate, validate, backtest, diagnose, learn, iterate N rounds. Self-improving alpha discovery and optimization. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-factor-mine](https://github.com/quantskills/skill-factor-mine) | Provides a factor-mining SOP from hypothesis and experiment notes through scoring and accept/rollback. | factor-generation | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-factor-mine.png"><img src="assets/skill-factor-mine.png" width="260"></a> |
 | [skill-factor-mining-pandaai](https://github.com/quantskills/skill-factor-mining-pandaai) | Mines factors with PandaAI data and feedback or extracts them from public documents. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-factor-optimize](https://github.com/quantskills/skill-factor-optimize) | Runs parameter sweeps, ablations, and version refinements for existing equity or futures factors. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
+| [skill-fundamental-alpha](https://github.com/quantskills/skill-fundamental-alpha) | Generate alpha factor expressions from fundamental data (PandaData). Accepts a document, URL, natural language query, or model invention and returns validated point-in-time factors. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-fundamental-factor-analysis](https://github.com/quantskills/skill-fundamental-factor-analysis) | Computes and validates A-share valuation, quality, and growth factors from quarterly financial reports. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
+| [skill-futures-transition-crowding-factor](https://github.com/quantskills/skill-futures-transition-crowding-factor) | Build an auditable futures factor from contract transitions and crowding shifts | evaluation | — | — | pending maintainer review / no public endpoint |  |
+| [skill-graph-spectral-diffusion-factor](https://github.com/quantskills/skill-graph-spectral-diffusion-factor) | Build auditable factor diffusion and residuals on point-in-time equity graphs | evaluation | — | — | pending maintainer review / no public endpoint |  |
+| [skill-hk-us-fundamental-factor](https://github.com/quantskills/skill-hk-us-fundamental-factor) | Build, standardize, compare, and validate multi-factor fundamental panels for Hong Kong and US equities from PandaAI operating, market-financial, industry-median, price-volume, and financial-statement APIs. Use for quality, value, growth, momentum, low-risk, composite-score, percentile-rank, or cross-market stock-screening tasks. | evaluation | — | — | pending maintainer review / no public endpoint |  |
+| [skill-llm-alpha-generator](https://github.com/quantskills/skill-llm-alpha-generator) | Mine formulaic alpha factors end to end: LLM 主导生成候选公式 → 三层校验（白名单/量纲/前视）→ warm-start 遗传编程精修 → AlphaEval 五维打分 → LLM 经济解释 → 自包含 HTML 报告，返回结构化因子结果。Use when the user wants to mine/discover alpha factors, generate formulaic (expression-tree) trading factors, run LLM+GP factor search, or evaluate factor predictive power (RankIC) on stocks or futures. 只挖因子、不做回测（回测归另一 skill）。 | evaluation | — | — | pending maintainer review / no public endpoint |  |
+| [skill-material-contract-alpha](https://github.com/quantskills/skill-material-contract-alpha) | A-share material contract alpha factor: cross-sectional ranking based on log-sum of contract amounts. | evaluation | — | — | pending maintainer review / no public endpoint |  |
+| [skill-minuteflow-alpha](https://github.com/quantskills/skill-minuteflow-alpha) | Generate alpha factor expressions from minute-level market data using PandaData (panda_data). Takes a research document or natural language query as input, fetches intraday OHLCV bars via get_market_min_data, extracts rich minute-level features (VWAP divergence, intraday momentum decay, order flow proxy, volatility curve shape, trade concentration, lead-lag signatures), and produces validated alpha expressions backed by a formula contract. Use when an agent needs to generate alpha ideas from academic papers, market commentary, or research notes that leverage intraday microstructure signals invisible in daily data. | evaluation | — | — | pending maintainer review / no public endpoint |  |
+| [skill-optimal-transport-cross-sectional-factor](https://github.com/quantskills/skill-optimal-transport-cross-sectional-factor) | Build auditable factors from point-in-time cross-sectional transport | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-overseas-equity-factor-miner](https://github.com/quantskills/skill-overseas-equity-factor-miner) | Discovers and validates HK and US cross-sectional alpha factors by IC, decay, and turnover. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-quant-factor-directional-alpha](https://github.com/quantskills/skill-quant-factor-directional-alpha) | Provides an OHLCV directional-factor library for trend, breakout, and reversal research. | factor-generation | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-quant-factor-directional-alpha.png"><img src="assets/skill-quant-factor-directional-alpha.png" width="260"></a> |
 | [skill-quant-factor-risk-pattern-alpha](https://github.com/quantskills/skill-quant-factor-risk-pattern-alpha) | Provides an OHLCV factor library for volatility, chart-pattern, and drawdown-pressure research. | factor-generation | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-quant-factor-risk-pattern-alpha.png"><img src="assets/skill-quant-factor-risk-pattern-alpha.png" width="260"></a> |
@@ -133,15 +143,18 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 | [skill-factor-ranking-sage](https://github.com/quantskills/skill-factor-ranking-sage) | Runs mRMR or Marginal-SAGE on local factor and label data to produce Top-K rankings. | factor-screening | — | — | pending maintainer review / no public endpoint |  |
 | [skill-residual-guided-factor-selection](https://github.com/quantskills/skill-residual-guided-factor-selection) | Selects factor combinations using residual IC and out-of-sample evaluation. | factor-screening | — | — | pending maintainer review / no public endpoint |  |
 
-### Factor Evaluation（5）
+### Factor Evaluation（8）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
 | [skill-build-b10-factor-evaluation](https://github.com/quantskills/skill-build-b10-factor-evaluation) | Evaluates quantitative factors with IC, IR, stratified backtests, monotonicity, turnover, and decay diagnostics. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-factor-evaluate](https://github.com/quantskills/skill-factor-evaluate) | Scores a cross-sectional factor using IC, Sharpe, drawdown, monotonicity, and turnover. | evaluation | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-factor-evaluate.png"><img src="assets/skill-factor-evaluate.png" width="260"></a> |
+| [skill-factor-ic-decay](https://github.com/quantskills/skill-factor-ic-decay) | Diagnose factor IC decay, ICIR, significance, rolling stability, and multi-horizon half-life. Evidence-first, no trading signals. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-factor-mason](https://github.com/quantskills/skill-factor-mason) | Checks timing, IC/IR, costs, and neutralization quality in single-factor research. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-factor-review](https://github.com/quantskills/skill-factor-review) | Scans a factor library and experiment logs for inventory, structural analysis, and research recommendations. | evaluation | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-factor-review.png"><img src="assets/skill-factor-review.png" width="260"></a> |
+| [skill-futures-cta-alpha](https://github.com/quantskills/skill-futures-cta-alpha) | Commodity-futures CTA factor library — computes a structured date×variety factor panel (time-series & cross-sectional momentum, carry/roll, term structure, positioning/COT, inventory, volatility). Use when the user asks for 商品期货因子、 CTA 信号、动量/carry/期限结构/库存/持仓因子, a factor panel for futures backtesting, or futures factor IC. Fills the ecosystem gap of ZERO futures factor libraries (vs 10 for equities). Emits factor values for the factor toolchain (factor-evaluate / ic-analysis / backtest), NOT human-readable reports. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-ic-analysis](https://github.com/quantskills/skill-ic-analysis) | Evaluates quantitative factors through IC, grouped performance, and predictive effectiveness. | evaluation | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-ic-analysis.png"><img src="assets/skill-ic-analysis.png" width="260"></a> |
+| [skill-quant-strategy-diagnostics](https://github.com/quantskills/skill-quant-strategy-diagnostics) | Check recent strategy or factor deterioration using returns, IC, drawdown, turnover, benchmarks, and market regimes. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 
 ### Factor Pool & Online Serving（2）
 
@@ -154,21 +167,29 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 
 <a id="cat-03"></a>
 <details>
-<summary><strong>03 Market & Instrument Analysis</strong> — 32 assets, 4 with screenshots</summary>
+<summary><strong>03 Market & Instrument Analysis</strong> — 44 assets, 4 with screenshots</summary>
 
-### A-Share Equities（7）
+### A-Share Equities（15）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
+| [skill-a-share-market-participation](https://github.com/quantskills/skill-a-share-market-participation) | Analyze A-share cross-sectional market participation, turnover concentration, liquidity distribution, speculative crowding, leader dependence, and structural fragility from daily or intraday stock snapshots. Use when the user asks in Chinese or English to analyze A-share market breadth, participation, turnover concentration, crowding, whether an index rally is broad or narrow, or to generate a reproducible market-structure report. Use only bundled scripts with PandaData as the primary live source, AKShare as fallback, or user-provided local data; never search, browse, or scrape webpages for replacement market data, and fail closed when approved sources are unavailable. Do not use for order routing, fill simulation, slippage/TCA, live trade execution, or stock-level margin/northbound/block-trade capital-flow attribution. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-a-share-stock-dossier](https://github.com/quantskills/skill-a-share-stock-dossier) | Uses Pandadata to produce a sourced A-share dossier covering fundamentals, corporate actions, holders, event risks, and market funds. | reporting | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-a-share-stock-dossier.png"><img src="assets/skill-a-share-stock-dossier.png" width="260"></a> |
+| [skill-a-share-tradability-auditor](https://github.com/quantskills/skill-a-share-tradability-auditor) | A-share tradability-constraint auditor — replays a backtest or signal trade log against date-resolved price limits (10%/20%/30%; main-board ST was 5% until the 2026-07-06 rule change), locked vs intraday-opened limit bars, suspensions, T+1 settlement, the naked-short ban, the new-listing window and turnover participation caps, then splits headline PnL into executable PnL and phantom PnL. Use when the user asks 回测收益是不是真的能成交、涨停买不进、 跌停卖不出、停牌怎么处理、T+1 约束、一字板、可交易性/可成交性审计, or wants to know why a live account underperforms its backtest. Fills the ecosystem gap: the four existing auditors all check whether the DATA is right, none checks whether the EXECUTION ASSUMPTION is possible. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-buffett-moat-screener](https://github.com/quantskills/skill-buffett-moat-screener) | Screens A-share and US companies using moat, valuation, and point-in-time data for research records. | modeling | — | — | pending maintainer review / no public endpoint |  |
+| [skill-buffett-moat-screener--lavineversion](https://github.com/quantskills/skill-buffett-moat-screener--lavineversion) | PandaData-only point-in-time Buffett moat hard screener for A-shares. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-concept-rotation-monitor](https://github.com/quantskills/skill-concept-rotation-monitor) | Monitors A-share concept and theme momentum, breadth, and rotation for research reports. | monitoring | — | — | pending maintainer review / no public endpoint |  |
 | [skill-dividend-yield-scan](https://github.com/quantskills/skill-dividend-yield-scan) | Calculates A-share rolling dividend yield, dividend continuity, and ex-dividend calendars. | reporting | — | — | pending maintainer review / no public endpoint |  |
+| [skill-equity-placard-watchlist](https://github.com/quantskills/skill-equity-placard-watchlist) | 举牌行为监控——侦测 A 股股东持股比例上穿 5%/10%/15%/20%/25%/30% 法定披露梯度的权益变动事件，含举牌梯度、意图倾向（财务 vs 战略）、6 个月锁定期、逼近举牌线观察名单。剔除通道账户与股本稀释造成的假举牌。BUILD 型 skill，可被复盘 agent 或事件驱动 Alpha 调用。 | reporting | — | — | pending maintainer review / no public endpoint |  |
+| [skill-graham-netnet-screener](https://github.com/quantskills/skill-graham-netnet-screener) | 当需要开发、计算、验证 Graham 净净营运资本(NCAV) 因子时，使用此 skill。适用于 A 股全市场深度价值筛选，排除银行/房地产/非银金融，计算 NCAV 折价因子并生成 buy/sell/hold 信号。 | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-holder-structure-scan](https://github.com/quantskills/skill-holder-structure-scan) | Tracks A-share holder counts, top-holder concentration, and free float to assess ownership concentration. | monitoring | — | — | pending maintainer review / no public endpoint |  |
 | [skill-post-market-screener](https://github.com/quantskills/skill-post-market-screener) | Screens A-share stocks after market close using technical patterns and capital-flow evidence. | factor-screening | — | — | pending maintainer review / no public endpoint |  |
+| [skill-soros-reflexivity-detector](https://github.com/quantskills/skill-soros-reflexivity-detector) | 索罗斯反身性识别器——用双环模型（快环情绪-资金 / 慢环基本面-资本）判断 A 股"这波涨跌是不是自我强化的反身性、转到哪一圈、燃料和裂缝在哪"，做阶段识别与仓位纪律。BUILD 型 skill，可被复盘 agent 或 Alpha 调用。 | reporting | — | — | pending maintainer review / no public endpoint |  |
+| [skill-stock-score](https://github.com/quantskills/skill-stock-score) | skill stock score | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-stock-screener](https://github.com/quantskills/skill-stock-screener) | Screens A-share stocks from natural-language criteria and Pandadata evidence. | factor-screening | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-stock-screener.png"><img src="assets/skill-stock-screener.png" width="260"></a> |
+| [skill-templeton-global-contrarian](https://github.com/quantskills/skill-templeton-global-contrarian) | 当需要开发、计算、验证 Templeton 全球价值多因子 V2 时，使用此 skill。适用于 A 股/港股/美股跨市场价值筛选，基于 EP/BP/SP/股息/ROE/杠杆/动量 七子因子截面打分，生成 buy/sell/hold 信号。 | reporting | — | — | pending maintainer review / no public endpoint |  |
 
-### HK & US Equities（9）
+### HK & US Equities（10）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
@@ -178,6 +199,7 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 | [skill-hk-us-consensus-revision-radar](https://github.com/quantskills/skill-hk-us-consensus-revision-radar) | Organizes cross-period HK/US target-price and rating revisions into a research report. | monitoring | — | — | pending maintainer review / no public endpoint |  |
 | [skill-hk-us-dividend-events](https://github.com/quantskills/skill-hk-us-dividend-events) | Generates HK and US equity dividend-event reports using Pandadata overseas-market interfaces. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-hk-us-insider-radar](https://github.com/quantskills/skill-hk-us-insider-radar) | Scans HK and US insider transactions, net direction, trading clusters, and holding changes. | monitoring | — | — | pending maintainer review / no public endpoint |  |
+| [skill-hk-us-institutional-concentration](https://github.com/quantskills/skill-hk-us-institutional-concentration) | Build, compare, and validate institutional ownership structure panels for Hong Kong and US equities with PandaAI investor concentration, ranking, and shareholder-report APIs. Use for ownership breadth, top-holder dominance, HHI, controlling-holder risk, evidence confidence, or within-market institutional ownership screening. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-hk-us-quote-scan](https://github.com/quantskills/skill-hk-us-quote-scan) | Builds HK and US equity snapshots covering quotes, liquidity, valuation, and industry-relative position. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-stock-memory-analyzer-usa](https://github.com/quantskills/skill-stock-memory-analyzer-usa) | Performs multidimensional research analysis of US memory-chip stocks. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-us-sector-rotation](https://github.com/quantskills/skill-us-sector-rotation) | Generates factual reports on US sector performance, valuation, and rotation. | reporting | — | — | pending maintainer review / no public endpoint |  |
@@ -191,13 +213,15 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 | [skill-index-rebalance-event-study](https://github.com/quantskills/skill-index-rebalance-event-study) | Runs reproducible event studies for index additions, deletions, and weight changes. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-index-valuation-rotation](https://github.com/quantskills/skill-index-valuation-rotation) | Analyzes A-share index valuation percentiles, relative industry valuation, and rotation signals. | reporting | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-index-valuation-rotation.png"><img src="assets/skill-index-valuation-rotation.png" width="260"></a> |
 
-### Futures & Commodities（6）
+### Futures & Commodities（8）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
 | [skill-ag-futures-seasonality](https://github.com/quantskills/skill-ag-futures-seasonality) | Computes monthly agricultural-futures seasonality from daily prices and overlays crop-calendar context. | modeling | — | — | pending maintainer review / no public endpoint |  |
 | [skill-commodity-carry-cta](https://github.com/quantskills/skill-commodity-carry-cta) | Builds commodity-futures carry, time-series momentum, cross-sectional momentum, basis, and inventory factors for rotation backtests. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-futures-deepview-analyst](https://github.com/quantskills/skill-futures-deepview-analyst) | Turns futures DeepView natural-language requests into data-call plans and fact/inference-separated reports. | reporting | — | — | pending maintainer review / no public endpoint |  |
+| [skill-futures-hedgecraft](https://github.com/quantskills/skill-futures-hedgecraft) | 当需要设计、审查或排错期货对冲、期货仓位 sizing、合约移仓、基差/carry 分析、日历价差、保证金压力测试或 CTA 风格期货配置时，使用此 skill。适用于股指期货、商品期货、利率期货和跨期价差场景，重点处理合约乘数、名义本金、保证金、期限结构、交割规则和压力损失。 | reporting | — | — | pending maintainer review / no public endpoint |  |
+| [skill-futures-investment-council](https://github.com/quantskills/skill-futures-investment-council) | Futures research Skill for analyzing, comparing, and screening futures markets with technical indicators, futures structure, and committee-style reports. Use when Codex needs to analyze a futures symbol, compare futures symbols, screen futures candidates, explain signal changes, or generate a structured futures research report without stock analysis, auto-trading, or deterministic buy/sell promises. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-global-commodity-term-structure](https://github.com/quantskills/skill-global-commodity-term-structure) | Uses public data to study global commodity-futures term structure, roll yield, and spreads. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-oil-brief](https://github.com/quantskills/skill-oil-brief) | Combines futures, EIA, OPEC, and market data into Chinese crude-oil briefs. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-xingtai-catcher](https://github.com/quantskills/skill-xingtai-catcher) | Retrieves similar A-share and futures K-line patterns from text or image descriptions. | factor-screening | — | — | pending maintainer review / no public endpoint |  |
@@ -210,19 +234,20 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 | [skill-option-strategy-builder](https://github.com/quantskills/skill-option-strategy-builder) | Builds option strategies with legs, payoff charts, breakevens, Greeks, and margin analysis. | portfolio-construction | — | — | pending maintainer review / no public endpoint |  |
 | [skill-options-vol-analyst](https://github.com/quantskills/skill-options-vol-analyst) | Analyzes option chains, implied and historical volatility, term structure, skew, and volatility premium. | modeling | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-options-vol-analyst.png"><img src="assets/skill-options-vol-analyst.png" width="260"></a> |
 
-### Macro & Cross-Asset（3）
+### Macro & Cross-Asset（4）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
 | [skill-global-macro-rates-fx-lab](https://github.com/quantskills/skill-global-macro-rates-fx-lab) | Produces sourced global macro briefs from public rates, central-bank, and FX data. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-macro-altdata-nowcast](https://github.com/quantskills/skill-macro-altdata-nowcast) | Uses high-frequency alternative macro data for industry nowcasts and trend monitoring. | modeling | — | — | pending maintainer review / no public endpoint |  |
+| [skill-macro-futures-scenario-analysis](https://github.com/quantskills/skill-macro-futures-scenario-analysis) | 基于 PandaData 的宏观事件—期货预期分析：读取宏观经济日历的实际值、市场预期与前值，结合期货价格、成交量、持仓量、基差、期限结构、库存与仓单，对沪金、沪铜、原油及用户指定品种输出基准、偏强、偏弱情景。当用户询问「美国CPI对期货影响」「宏观事件期货预期」「美联储对商品影响」「期货供需与宏观共振」「事件公布前情景」时触发。仅作条件化研究，不承诺涨跌或生成自动交易指令。 | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-macro-monitor](https://github.com/quantskills/skill-macro-monitor) | Monitors macro data, industry conditions, economic calendars, and recurring macro changes. | monitoring | — | — | pending maintainer review / no public endpoint |  |
 
 </details>
 
 <a id="cat-04"></a>
 <details>
-<summary><strong>04 Risk Monitoring & Alerts</strong> — 19 assets, 1 with screenshots</summary>
+<summary><strong>04 Risk Monitoring & Alerts</strong> — 22 assets, 1 with screenshots</summary>
 
 ### Market Regime（1）
 
@@ -255,17 +280,20 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 | [skill-klarman-special-situations](https://github.com/quantskills/skill-klarman-special-situations) | Researches private placements, restructurings, spin-offs, and distressed turnarounds as special situations. | modeling | — | — | pending maintainer review / no public endpoint |  |
 | [skill-refinancing-monitor](https://github.com/quantskills/skill-refinancing-monitor) | Tracks A-share refinancing lifecycles, pricing, and dilution risk. | monitoring | — | — | pending maintainer review / no public endpoint |  |
 
-### Regulatory Compliance（2）
+### Regulatory Compliance（3）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
 | [skill-audit-opinion-scanner](https://github.com/quantskills/skill-audit-opinion-scanner) | Assesses A-share financial health from audit opinions, statements, and industry benchmarks with risk checks. | evaluation | — | — | pending maintainer review / no public endpoint |  |
+| [skill-csrc-approval-pipeline](https://github.com/quantskills/skill-csrc-approval-pipeline) | A-share CSRC approval pipeline tracking: categorization by announcement level, approval flow monitoring, and status report generation. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-regulatory-risk-radar](https://github.com/quantskills/skill-regulatory-risk-radar) | Aggregates and grades A-share regulatory and compliance risk events. | monitoring | — | — | pending maintainer review / no public endpoint |  |
 
-### Portfolio Stress Testing（4）
+### Portfolio Stress Testing（6）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
+| [skill-derivatives-pricing-stochastic-calculus](https://github.com/quantskills/skill-derivatives-pricing-stochastic-calculus) | Price options and other derivatives and quantify their risk from a contract specification and market inputs, covering Black-Scholes-Merton analytical pricing, the full set of Greeks, binomial-tree and Monte-Carlo numerical pricing with convergence checks, implied-volatility inversion, volatility smile/skew structure, and model-risk validation (put-call parity, no-arbitrage bounds, cross-method consistency). Use when the user asks for 期权定价、希腊字母计算、隐含波动率、波动率微笑/曲面、二叉树或蒙特卡洛定价、Black-Scholes、美式期权定价、看跌看涨平价校验, or a one-stop option pricing and risk dossier. | reporting | — | — | pending maintainer review / no public endpoint |  |
+| [skill-guarantee-risk-scan](https://github.com/quantskills/skill-guarantee-risk-scan) | A-share cumulative guarantee risk scanning: guarantee ratio, excess guarantee, and high-debt-ratio guarantee monitoring and alerting. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-portfolio-checkup](https://github.com/quantskills/skill-portfolio-checkup) | Aggregates concentration, benchmark deviation, valuation, quality, and risk exposures into a portfolio health report. | risk | — | — | pending maintainer review / no public endpoint |  |
 | [skill-quant-portfolio-risk](https://github.com/quantskills/skill-quant-portfolio-risk) | Analyzes portfolio risk exposures, constraints, and stress scenarios. | risk | — | — | pending maintainer review / no public endpoint |  |
 | [skill-risk-model](https://github.com/quantskills/skill-risk-model) | Builds a multifactor risk model and performs risk attribution. | risk | — | — | pending maintainer review / no public endpoint |  |
@@ -282,7 +310,7 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 
 <a id="cat-05"></a>
 <details>
-<summary><strong>05 Backtesting & Trading</strong> — 18 assets, 2 with screenshots</summary>
+<summary><strong>05 Backtesting & Trading</strong> — 25 assets, 2 with screenshots</summary>
 
 ### Strategies & Signals（4）
 
@@ -293,12 +321,17 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 | [skill-oversold-rebound](https://github.com/quantskills/skill-oversold-rebound) | Identifies A-share oversold-rebound conditions and screens candidate stocks. | factor-screening | — | — | pending maintainer review / no public endpoint |  |
 | [skill-qbti](https://github.com/quantskills/skill-qbti) | Translates a five-part user questionnaire into factor directions and strategy parameters. | portfolio-construction | — | — | pending maintainer review / no public endpoint |  |
 
-### Portfolio Construction（2）
+### Portfolio Construction（7）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
 | [skill-dalio-all-weather](https://github.com/quantskills/skill-dalio-all-weather) | Provides an all-weather allocation and backtest workflow for A-share assets, bonds, gold, and commodities. | portfolio-construction | — | — | pending maintainer review / no public endpoint |  |
+| [skill-portfolio-blacklitterman](https://github.com/quantskills/skill-portfolio-blacklitterman) | Black-Litterman 组合优化 —— 用户问「跑一下 BL 组合」「基于视图的组合权重」「相对沪深300 的主动配置」「动量/反转/换手视图对权重的影响」类问题时触发。以沪深300 指数权重为先验，用动量/反转/换手率三条因子视图更新，输出长权重组合，按「样式② 结构化播报」呈现给用户。 | risk | — | — | pending maintainer review / no public endpoint |  |
+| [skill-portfolio-cvar-optim](https://github.com/quantskills/skill-portfolio-cvar-optim) | 当需要开发、计算、验证 CVaR 尾部风险最小化组合时，使用此 skill。在预期收益约束下最小化组合 95% CVaR，支持极值理论(EVT/GPD)尾部补样、组合权重求解、样本外验证。 | risk | — | — | pending maintainer review / no public endpoint |  |
 | [skill-portfolio-optimize](https://github.com/quantskills/skill-portfolio-optimize) | Turns alpha signals into optimized weights under weight, sector, exposure, and turnover constraints. | portfolio-construction | — | — | pending maintainer review / no public endpoint |  |
+| [skill-portfolio-risk-parity](https://github.com/quantskills/skill-portfolio-risk-parity) | 当需要开发、计算、验证风险平价（等风险贡献 ERC）组合时使用。手写 Ledoit-Wolf 收缩协方差稳定相关性，scipy SLSQP 求 ERC 权重，支持指数/期货/ETF 三类资产与月度 rebalance。 | risk | — | — | pending maintainer review / no public endpoint |  |
+| [skill-rl-portfolio-allocator](https://github.com/quantskills/skill-rl-portfolio-allocator) | skill rl portfolio allocator | risk | — | — | pending maintainer review / no public endpoint |  |
+| [skill-signal-portfolio-optimize](https://github.com/quantskills/skill-signal-portfolio-optimize) | Converts one stock signal into benchmark-relative target weights with auditable risk, exposure, turnover, and cost controls. | portfolio-construction | — | — | pending maintainer review / no public endpoint |  |
 
 ### Backtesting Engine（2）
 
@@ -316,17 +349,19 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 | [skill-risk-return-metrics](https://github.com/quantskills/skill-risk-return-metrics) | Calculates risk-return metrics for portfolios or strategies. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-strategy-tearsheet-report](https://github.com/quantskills/skill-strategy-tearsheet-report) | Generates strategy-performance tearsheets with risk-adjusted metrics. | reporting | — | — | pending maintainer review / no public endpoint |  |
 
-### Transaction Costs（2）
+### Transaction Costs（3）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
+| [skill-strategy-capacity-tca](https://github.com/quantskills/skill-strategy-capacity-tca) | Estimate strategy capacity and transaction costs from trades and ADV — participation, square-root/linear impact, capacity curve and breakeven vs alpha. Estimates only, no trade advice. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-transaction-cost-analysis](https://github.com/quantskills/skill-transaction-cost-analysis) | Decomposes fills against VWAP/TWAP into transaction-cost components. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-transaction-cost-calibration](https://github.com/quantskills/skill-transaction-cost-calibration) | Calibrates commission, spread, slippage, and market-impact assumptions from execution and market data. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 
-### Market Microstructure（1）
+### Market Microstructure（2）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
+| [skill-microstructure-vwap-deviation](https://github.com/quantskills/skill-microstructure-vwap-deviation) | Minute-bar VWAP deviation strategy research and auditable SSQuant futures validation. Use for rolling VWAP deviation signals, confirmed mean reversion, trend guards, next-bar execution, execution-cost modeling, frozen-data backtests, and trade-result review. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-quant-execution-microstructure](https://github.com/quantskills/skill-quant-execution-microstructure) | Converts approved trade targets into observable, cost-aware execution plans. | execution | — | — | pending maintainer review / no public endpoint |  |
 
 ### Positions & Orders（2）
@@ -346,14 +381,13 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 
 <a id="cat-06"></a>
 <details>
-<summary><strong>06 Research Models & Replication</strong> — 18 assets, 7 with screenshots</summary>
+<summary><strong>06 Research Models & Replication</strong> — 30 assets, 6 with screenshots</summary>
 
-### Paper Replication（2）
+### Paper Replication（1）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
 | [skill-paper-replication](https://github.com/quantskills/skill-paper-replication) | Supports paper search, data extraction, experiment reproduction, and research-result reporting. | modeling | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-paper-replication.png"><img src="assets/skill-paper-replication.png" width="260"></a> |
-| [skill-quant-research-replication](https://github.com/quantskills/skill-quant-research-replication) | Guides auditable quantitative-research replication workflows. | modeling | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-quant-research-replication.png"><img src="assets/skill-quant-research-replication.png" width="260"></a> |
 
 ### Strategy Replication（1）
 
@@ -361,27 +395,40 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 |---|---|---|---|---|---|---|
 | [skill-report-replication](https://github.com/quantskills/skill-report-replication) | Guides conversion of research reports into reproducible analysis workflows. | modeling | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-report-replication.png"><img src="assets/skill-report-replication.png" width="260"></a> |
 
-### Statistical & ML Models（6）
+### Statistical & ML Models（11）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
+| [skill-dl-autoencoder-anomaly](https://github.com/quantskills/skill-dl-autoencoder-anomaly) | 深度自编码器无监督异常检测 —— 用户问「今天哪些股票走势最异常」「沪深300 异常股」「AE 跑一下」「找不像自己往常样子的股票」类问题时触发。对沪深300成分股用最近60日窗口重训一个MLP自编码器，输出T日重建误差Top-10异常股，按「样式② 结构化播报」呈现。 | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-dl-gnn-stock-graph](https://github.com/quantskills/skill-dl-gnn-stock-graph) | Builds A-share heterogeneous graphs for GNN stock selection and backtesting. | modeling | — | — | pending maintainer review / no public endpoint |  |
+| [skill-dl-tcn-shortterm](https://github.com/quantskills/skill-dl-tcn-shortterm) | 使用因果扩张 Temporal Convolutional Network 对沪深 A 股分钟线执行未来 1、2、3、5 个交易日的横截面收益排序研究，并以同数据、切分和预算的 LSTM 作为基准，生成可审计的数据、训练、速度和预测效果证据。用于运行或诊断 TCN 短线预测、核验感受野与因果卷积、PIT/walk-forward/purge/embargo、防止未来泄漏、比较 RankIC/Top 区域指标与训练吞吐，或判断研究模型是否达到冻结候选条件；不用于组合换手优化、券商连接、实盘交易或收益承诺。 | evaluation | — | — | pending maintainer review / no public endpoint |  |
+| [skill-dl-transformer-multiasset](https://github.com/quantskills/skill-dl-transformer-multiasset) | skill dl transformer multiasset | evaluation | — | — | pending maintainer review / no public endpoint |  |
+| [skill-llm-rag-financial-qa](https://github.com/quantskills/skill-llm-rag-financial-qa) | 财报公告 RAG 问答系统——就一家 A 股公司的财报/公告提问，给出带官方引用、可核对、拒绝编造的回答。三路路由（数字精确算 / 底仓文本检索 / 官方全文按需）+ 引用纪律 + 拒答。数据源 PandaData 优先、官方披露网页为次级源。BUILD 型 skill，可被复盘 agent 或投研 agent 调用。 | evaluation | — | — | pending maintainer review / no public endpoint |  |
+| [skill-ml-purged-cv](https://github.com/quantskills/skill-ml-purged-cv) | 审计任意金融特征、可训练时序模型或候选策略收益，并执行防泄漏的 Purged K-Fold、Embargo、CPCV、Causal Walk-Forward、PBO、DSR、Governed Holdout 与 Temporal Forward Evidence。用于检查未来函数、信息区间重叠、特征可用时间和血缘、Fold-Local 预处理、CPCV Path 稳健性、策略选择过拟合、预测是否在标签成熟前登记，以及在接受金融模型或策略前生成结构化验证证据。 | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-model-hpo-evidence-driven](https://github.com/quantskills/skill-model-hpo-evidence-driven) | Optimizes quantitative multi-factor model hyperparameters with fixed validation and trial-level evidence. | modeling | — | — | pending maintainer review / no public endpoint |  |
 | [skill-pair-correlation](https://github.com/quantskills/skill-pair-correlation) | Computes and interprets asset-pair correlations, rolling relationships, and research uses. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-simons-pairs-trading](https://github.com/quantskills/skill-simons-pairs-trading) | Studies A-share pairs trading with cointegration, spreads, and execution constraints. | modeling | — | — | pending maintainer review / no public endpoint |  |
 | [skill-statistical-arbitrage-time-series](https://github.com/quantskills/skill-statistical-arbitrage-time-series) | Builds statistical-arbitrage time-series research and produces traceable reports. | modeling | — | — | pending maintainer review / no public endpoint |  |
 | [skill-time-series-analysis](https://github.com/quantskills/skill-time-series-analysis) | Diagnoses financial time series and produces analysis reports. | modeling | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-time-series-analysis.png"><img src="assets/skill-time-series-analysis.png" width="260"></a> |
 
-### Investor Research Models（7）
+### Investor Research Models（15）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
+| [skill-ah-share-relative-value-montior](https://github.com/quantskills/skill-ah-share-relative-value-montior) | Monitor FX-adjusted A/H premiums, historical extremes, dislocations, and daily cross-market price-discovery proxies. | reporting | — | — | pending maintainer review / no public endpoint |  |
+| [skill-etf-flow-radar](https://github.com/quantskills/skill-etf-flow-radar) | 每日盘后 ETF 资金流雷达 —— 用户问「今天/最近 ETF 有什么异动」「ETF 资金流看下」「哪些 ETF 在被大量申购/赎回」「ETF 净申赎异动」类问题时触发。扫描主流权益 ETF，输出三类信号（净申赎异动 / 折溢价背离 / 连续多日大额同向），以「样式② 结构化播报」呈现给用户。 | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-gaetano-crux-capital-research-model](https://github.com/quantskills/skill-gaetano-crux-capital-research-model) | Uses public sources to structure research evidence and risks for photonics, optical-network, and AI-infrastructure companies. | modeling | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-gaetano-crux-capital-research-model.png"><img src="assets/skill-gaetano-crux-capital-research-model.png" width="260"></a> |
 | [skill-gao-shanwen-research-model](https://github.com/quantskills/skill-gao-shanwen-research-model) | Organizes, retrieves, and studies Gao Shanwen's public writings and articles. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-investment-decision](https://github.com/quantskills/skill-investment-decision) | Combines research evidence, valuation, and risk information into an auditable investment decision report. | modeling | — | — | pending maintainer review / no public endpoint |  |
 | [skill-keynes-contrarian-investment](https://github.com/quantskills/skill-keynes-contrarian-investment) | Uses long-term expectations and contrarian analysis to identify optimism, pessimism, and value traps. | modeling | — | — | pending maintainer review / no public endpoint |  |
+| [skill-kline-pattern-vision](https://github.com/quantskills/skill-kline-pattern-vision) | 用截图或只读 PandaData 行情识别股票/期货K线趋势结构、蜡烛线和候选图表形态，支持日线与1/5/10/15/30/60分钟线，输出证据、确认条件、失效条件和不确定性。 | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-munger-mental-model](https://github.com/quantskills/skill-munger-mental-model) | Applies a multidisciplinary mental-model framework to company investment research and judgment reports. | modeling | — | — | pending maintainer review / no public endpoint |  |
+| [skill-performance-attribution](https://github.com/quantskills/skill-performance-attribution) | Use when an agent needs to attribute the returns of an A-share quant strategy or portfolio — decompose performance into Alpha/Beta/timing, Brinson allocation/selection/interaction effects by industry, and factor-return contributions (style factors, industry, residual Alpha). Outputs a unified AttributionReport (Markdown + JSON) with reconciliation checks. | reporting | — | — | pending maintainer review / no public endpoint |  |
+| [skill-rotation-radar](https://github.com/quantskills/skill-rotation-radar) | 当需要分析市场状态、行业轮动、ETF 强弱排序、市场宽度、风格切换或战术配置信号时，使用此 skill。适用于 A 股、港股、美股和 ETF 池的行业轮动分析、risk-on/risk-off 状态识别、相对强弱排名、宽度确认、假突破过滤和轮动失效条件设计。 | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-serenity-research-model](https://github.com/quantskills/skill-serenity-research-model) | Reconstructs Serenity-style research logic from public X/Twitter evidence. | modeling | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-serenity-research-model.png"><img src="assets/skill-serenity-research-model.png" width="260"></a> |
+| [skill-shortterm-mean-reversal](https://github.com/quantskills/skill-shortterm-mean-reversal) | Cost-aware A-share five-session cross-sectional return reversal research. | reporting | — | — | pending maintainer review / no public endpoint |  |
+| [skill-tqx-research](https://github.com/quantskills/skill-tqx-research) | skill tqx research | reporting | — | — | pending maintainer review / no public endpoint |  |
+| [skill-trendline-breakdown-reversal](https://github.com/quantskills/skill-trendline-breakdown-reversal) | 计算A股日线下跌突破划线压力位反转因子，识别下破下降压力线后反转确认的个股；当用户提供交易日期、要求自动获取当日全市场A股行情、量化选股、因子研究或回测时使用。 | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-x-trader-builder](https://github.com/quantskills/skill-x-trader-builder) | Builds trader-specific research-model skills from public X/Twitter post data. | orchestration | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-x-trader-builder.png"><img src="assets/skill-x-trader-builder.png" width="260"></a> |
 
 ### Experiment Registry & Reproducible Research（2）
@@ -395,7 +442,7 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 
 <a id="cat-07"></a>
 <details>
-<summary><strong>07 Research Validation & Quality</strong> — 11 assets, 1 with screenshots</summary>
+<summary><strong>07 Research Validation & Quality</strong> — 12 assets, 1 with screenshots</summary>
 
 ### Lookahead & Data Leakage（2）
 
@@ -437,22 +484,25 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 |---|---|---|---|---|---|---|
 | [skill-factor-debug](https://github.com/quantskills/skill-factor-debug) | Provides a symptom, cause, and verification playbook for factor failures. | evaluation | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-factor-debug.png"><img src="assets/skill-factor-debug.png" width="260"></a> |
 
-### Workflow Audit（1）
+### Workflow Audit（2）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
+| [skill-backtest-assumption_check](https://github.com/quantskills/skill-backtest-assumption_check) | Use when an agent needs to independently audit the assumptions and biases behind a backtest / strategy code / research backtest report — execution timing and lookahead, trading costs, price limits and suspensions, survivorship bias, parameter freedom and multiple testing, data alignment and adjustment, turnover and capacity, benchmark and excess returns, and reporting transparency. Outputs a structured defect list (axis x evidence x severity x impact x fix). | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-pandaai-workflow-audit](https://github.com/quantskills/skill-pandaai-workflow-audit) | Audits PandaAI workflow graphs, code, timing, parameters, and backtest-validation evidence. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 
 </details>
 
 <a id="cat-08"></a>
 <details>
-<summary><strong>08 Information Search & Knowledge Analysis</strong> — 6 assets, 1 with screenshots</summary>
+<summary><strong>08 Information Search & Knowledge Analysis</strong> — 10 assets, 1 with screenshots</summary>
 
-### News & Disclosures（3）
+### News & Disclosures（5）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
+| [skill-disclosure-event-extractor](https://github.com/quantskills/skill-disclosure-event-extractor) | Turn unstructured A-share disclosure text from cninfo (巨潮) and the SSE/SZSE exchanges into a traceable, structured event table (监管问询/诉讼担保/重组/治理/ 停牌控制权变更/增减持/质押/业绩预告). Use when the user asks to scan A-share announcements, find 关注函/问询函/诉讼/停牌/易主 events, build an event table for factor or alert pipelines, or backtest disclosure events. Fills the information-search gap Pandadata does not cover. | reporting | — | — | pending maintainer review / no public endpoint |  |
+| [skill-earnings-event-study](https://github.com/quantskills/skill-earnings-event-study) | Formal CAR event study around earnings/corporate events — abnormal returns, multi-window CARs, t-tests and sign tests, with sample and model disclosure; research only, no trading advice. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-earnings-season-tracker](https://github.com/quantskills/skill-earnings-season-tracker) | Scans earnings guidance, industry distributions, and qualified audit items during earnings seasons. | monitoring | — | — | pending maintainer review / no public endpoint |  |
 | [skill-fin-news](https://github.com/quantskills/skill-fin-news) | Aggregates financial headlines and market data to select headlines and draft analysis articles. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-news-sentiment-analyst](https://github.com/quantskills/skill-news-sentiment-analyst) | Collects, verifies, and analyzes A-share financial-news sentiment for research reports. | modeling | — | — | pending maintainer review / no public endpoint |  |
@@ -463,32 +513,39 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 |---|---|---|---|---|---|---|
 | [skill-institutional-research-tracker](https://github.com/quantskills/skill-institutional-research-tracker) | Monitors A-share institutional research activity, attention, and changes over time. | monitoring | — | — | pending maintainer review / no public endpoint |  |
 
-### Daily Review（2）
+### Daily Review（4）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
 | [skill-daily-report](https://github.com/quantskills/skill-daily-report) | Aggregates cross-market prices, sectors, flows, and news into a daily Markdown review. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [skill-market-daily-review](https://github.com/quantskills/skill-market-daily-review) | Generates Pandadata-based A-share after-close daily market review reports. | reporting | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-market-daily-review.png"><img src="assets/skill-market-daily-review.png" width="260"></a> |
+| [skill-strategy-performance-report](https://github.com/quantskills/skill-strategy-performance-report) | Use when an agent needs to generate a periodic performance report for a LIVE A-share quant strategy — 日报/周报/月报/半年报/年报 or custom period — covering returns, risk, trade analysis, and position/turnover detail, with embedded visualizations. Outputs a self-contained offline HTML dashboard (interactive ECharts) plus Markdown + JSON. | reporting | — | — | pending maintainer review / no public endpoint |  |
+| [skill-trade-review](https://github.com/quantskills/skill-trade-review) | Trade review skill that turns trade records into attribution, pattern detection, per-trade review, and actionable advice. | reporting | — | — | pending maintainer review / no public endpoint |  |
 
 </details>
 
 <a id="cat-09"></a>
 <details>
-<summary><strong>09 Quant Agents & Automation</strong> — 8 assets, 5 with screenshots</summary>
+<summary><strong>09 Quant Agents & Automation</strong> — 14 assets, 5 with screenshots</summary>
 
-### Research Agent（2）
+### Research Agent（3）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
 | [agent-correlation-break-research](https://github.com/quantskills/agent-correlation-break-research) | Uses Pandadata price-series correlation changes to identify style shifts, diversification stress, and structural market moves. | monitoring | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/agent-correlation-break-research.png"><img src="assets/agent-correlation-break-research.png" width="260"></a> |
+| [agent-feng-reverse](https://github.com/quantskills/agent-feng-reverse) | Tracks Weibo user "峰哥亡命天涯" (Feng Ge), a well-known A-share reverse indicator. Extracts stock/market opinions from his posts and generates contrarian trading signals. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [agent-macro-driven-rotation](https://github.com/quantskills/agent-macro-driven-rotation) | Generates macro-driven industry-rotation research materials from clock phases, nowcasts, and valuation filters. | modeling | — | — | pending maintainer review / no public endpoint |  |
 
-### Monitoring & Risk Agent（3）
+### Monitoring & Risk Agent（7）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
+| [agent-alpha-portfolio-guardian](https://github.com/quantskills/agent-alpha-portfolio-guardian) | Multi-factor portfolio health guardian producing a health matrix, crowding alerts, retire/rebuild candidates, IC decay curves, and a research-only effectiveness backtest L4 page. | reporting | — | — | pending maintainer review / no public endpoint |  |
+| [agent-corporate-governance-scanner](https://github.com/quantskills/agent-corporate-governance-scanner) | Corporate governance scoring agent with 9-dimension risk scoring and evidence chains | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [agent-crowding-risk-monitor](https://github.com/quantskills/agent-crowding-risk-monitor) | Monitors crowded-trade risk from Pandadata price, turnover, margin, and Dragon-Tiger heat evidence. | monitoring | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/agent-crowding-risk-monitor.png"><img src="assets/agent-crowding-risk-monitor.png" width="260"></a> |
 | [agent-derivatives-skew-sentiment-monitor](https://github.com/quantskills/agent-derivatives-skew-sentiment-monitor) | Monitors derivatives sentiment from option implied volatility and underlying historical volatility. | monitoring | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/agent-derivatives-skew-sentiment-monitor.png"><img src="assets/agent-derivatives-skew-sentiment-monitor.png" width="260"></a> |
+| [agent-earnings-surprise-hunter](https://github.com/quantskills/agent-earnings-surprise-hunter) | 财报季 Surprise/暴雷猎手 Agent。获取财报预告、一致预期、审计意见，计算偏离度并生成分析报告。支持A股/港股/美股。 | reporting | — | — | pending maintainer review / no public endpoint |  |
+| [agent-intraday-rl-timing](https://github.com/quantskills/agent-intraday-rl-timing) | Research-only RL lab for intraday timing on minute bars: Gym env, baseline policies, leakage-aware walk-forward train/eval. No live orders. | reporting | — | — | pending maintainer review / no public endpoint |  |
 | [agent-market-regime-monitor](https://github.com/quantskills/agent-market-regime-monitor) | Monitors market regimes from Pandadata index breadth, volatility, and funding evidence. | monitoring | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/agent-market-regime-monitor.png"><img src="assets/agent-market-regime-monitor.png" width="260"></a> |
 
 ### Trading Execution Agent（1）
@@ -497,11 +554,12 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 |---|---|---|---|---|---|---|
 | [agent-ssquant](https://github.com/quantskills/agent-ssquant) | SSQuant Agent workflow for futures strategies, data services, CTP gates, and Chinese backtest reports. | execution | — | — | pending maintainer review / no public endpoint |  |
 
-### Workflow Orchestration Agent（2）
+### Workflow Orchestration Agent（3）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
 | [agent-for-liangshuyuan-tasks](https://github.com/quantskills/agent-for-liangshuyuan-tasks) | Multi-agent collaboration framework for Liangshuyuan tasks, organizing quantitative tools, build workflows, and task roles. | orchestration | — | — | pending maintainer review / no public endpoint |  |
+| [agent-future-trading](https://github.com/quantskills/agent-future-trading) | Multi-agent futures research, strategy generation, backtesting, and research feedback workflow | orchestration | — | — | pending maintainer review / no public endpoint |  |
 | [agent-quantspace](https://github.com/quantskills/agent-quantspace) | AI-native quantitative research framework for reusable skills, strategy workflows, backtests, and reports. | orchestration | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/agent-quantspace.png"><img src="assets/agent-quantspace.png" width="260"></a> |
 
 </details>

--- a/README.en.md
+++ b/README.en.md
@@ -25,20 +25,20 @@ Quantitative experience should be described, reproduced, and discussed openly: c
 A periodic snapshot of the community's public assets; browse the interactive catalog at [www.quantskills.ai](https://www.quantskills.ai/).
 
 <!-- CATALOG:START -->
-<!-- catalog-snapshot: sha256:ecb9a3d03c6df06f3d5ca7961766ad2927ab3d370ee64e80343c0dd6946567a7 -->
+<!-- catalog-snapshot: sha256:117387f24ed230521243f50541e0d1f8c10cd949848b4ba095c55222ba833c00 -->
 <table align="center"><tr>
-<td align="center"><strong>158</strong><br><sub>Assets</sub></td>
+<td align="center"><strong>156</strong><br><sub>Assets</sub></td>
 <td align="center"><strong>10</strong><br><sub>Categories</sub></td>
 <td align="center"><strong>1</strong><br><sub>Published endpoints</sub></td>
-<td align="center"><strong>2026-08-11</strong><br><sub>Snapshot updated</sub></td>
+<td align="center"><strong>2026-08-29</strong><br><sub>Snapshot updated</sub></td>
 </tr></table>
 
 ## Category summary
 - [01 Data APIs & Warehouse](#cat-01) — 7 assets（Data Sources & Connectors / Warehouse & Cache / Market Data Governance / PIT & Data Quality）
-- [02 Factor R&D Toolbox](#cat-02) — 32 assets（Factor Ideation / Factor Generation / Orthogonalization & Blending / Factor Selection / Factor Evaluation / Factor Pool & Online Serving）
+- [02 Factor R&D Toolbox](#cat-02) — 31 assets（Factor Ideation / Factor Generation / Orthogonalization & Blending / Factor Selection / Factor Evaluation / Factor Pool & Online Serving）
 - [03 Market & Instrument Analysis](#cat-03) — 32 assets（A-Share Equities / HK & US Equities / ETFs, Funds & Indices / Futures & Commodities / Options & Convertible Bonds / Macro & Cross-Asset）
 - [04 Risk Monitoring & Alerts](#cat-04) — 19 assets（Market Regime / Flows & Crowding / Liquidity Risk / Corporate Events / Regulatory Compliance / Portfolio Stress Testing / Automated Alerts）
-- [05 Backtesting & Trading](#cat-05) — 19 assets（Strategies & Signals / Portfolio Construction / Backtesting Engine / Performance Attribution / Transaction Costs / Market Microstructure / Positions & Orders / Paper & Live Execution）
+- [05 Backtesting & Trading](#cat-05) — 18 assets（Strategies & Signals / Portfolio Construction / Backtesting Engine / Performance Attribution / Transaction Costs / Market Microstructure / Positions & Orders / Paper & Live Execution）
 - [06 Research Models & Replication](#cat-06) — 18 assets（Paper Replication / Strategy Replication / Statistical & ML Models / Investor Research Models / Experiment Registry & Reproducible Research）
 - [07 Research Validation & Quality](#cat-07) — 11 assets（Lookahead & Data Leakage / Survivorship Bias / Walk-Forward & OOS / Signal Stability / Forecast Calibration / Numerical & Model Audit / Workflow Audit）
 - [08 Information Search & Knowledge Analysis](#cat-08) — 6 assets（News & Disclosures / Institutional Research / Daily Review）
@@ -87,7 +87,7 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 
 <a id="cat-02"></a>
 <details>
-<summary><strong>02 Factor R&D Toolbox</strong> — 32 assets, 9 with screenshots</summary>
+<summary><strong>02 Factor R&D Toolbox</strong> — 31 assets, 8 with screenshots</summary>
 
 ### Factor Ideation（2）
 
@@ -96,7 +96,7 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 | [skill-factor-idea-generation](https://github.com/quantskills/skill-factor-idea-generation) | Generates candidate factor ideas with economic rationale and risk notes from the default data scope. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-factormad-debate-factor-mining](https://github.com/quantskills/skill-factormad-debate-factor-mining) | Uses a FactorMAD-style multi-agent debate framework for interpretable stock-alpha mining. | factor-generation | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-factormad-debate-factor-mining.png"><img src="assets/skill-factormad-debate-factor-mining.png" width="260"></a> |
 
-### Factor Generation（17）
+### Factor Generation（16）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
@@ -116,7 +116,6 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 | [skill-overseas-equity-factor-miner](https://github.com/quantskills/skill-overseas-equity-factor-miner) | Discovers and validates HK and US cross-sectional alpha factors by IC, decay, and turnover. | factor-generation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-quant-factor-directional-alpha](https://github.com/quantskills/skill-quant-factor-directional-alpha) | Provides an OHLCV directional-factor library for trend, breakout, and reversal research. | factor-generation | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-quant-factor-directional-alpha.png"><img src="assets/skill-quant-factor-directional-alpha.png" width="260"></a> |
 | [skill-quant-factor-risk-pattern-alpha](https://github.com/quantskills/skill-quant-factor-risk-pattern-alpha) | Provides an OHLCV factor library for volatility, chart-pattern, and drawdown-pressure research. | factor-generation | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-quant-factor-risk-pattern-alpha.png"><img src="assets/skill-quant-factor-risk-pattern-alpha.png" width="260"></a> |
-| [skill-quant-factor-volume-stat-alpha](https://github.com/quantskills/skill-quant-factor-volume-stat-alpha) | Provides an OHLCV factor library for volume and price-volume statistical research. | factor-generation | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-quant-factor-volume-stat-alpha.png"><img src="assets/skill-quant-factor-volume-stat-alpha.png" width="260"></a> |
 
 ### Orthogonalization & Blending（3）
 
@@ -283,7 +282,7 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 
 <a id="cat-05"></a>
 <details>
-<summary><strong>05 Backtesting & Trading</strong> — 19 assets, 2 with screenshots</summary>
+<summary><strong>05 Backtesting & Trading</strong> — 18 assets, 2 with screenshots</summary>
 
 ### Strategies & Signals（4）
 
@@ -308,11 +307,10 @@ A periodic snapshot of the community's public assets; browse the interactive cat
 | [skill-backtest](https://github.com/quantskills/skill-backtest) | Provides a cross-sectional long-only backtest protocol with T+1 execution, fees, limit filters, and diagnostics. | backtesting | — | — | pending maintainer review / no public endpoint | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-backtest.png"><img src="assets/skill-backtest.png" width="260"></a> |
 | [skill-factor-backtest](https://github.com/quantskills/skill-factor-backtest) | Runs long-only cross-sectional factor backtests on supplied factors and market data with diagnostics. | backtesting | — | — | pending maintainer review / no public endpoint |  |
 
-### Performance Attribution（5）
+### Performance Attribution（4）
 
 | Project | Bilingual summary | Primary stage | Inputs | Outputs | Interface status | Screenshot |
 |---|---|---|---|---|---|---|
-| [skill-brinson-performance-attribution](https://github.com/quantskills/skill-brinson-performance-attribution) | Runs Brinson-Fachler or BHB attribution with HHI, contributor ranking, and Carino multi-period linking. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-portfolio-attribution](https://github.com/quantskills/skill-portfolio-attribution) | Attributes active portfolio returns to industry allocation, stock selection, interaction, and factor contributions. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-portfolio-pnl-attribution](https://github.com/quantskills/skill-portfolio-pnl-attribution) | Attributes realized portfolio returns by security and sector while reconciling fees, benchmarks, and input quality. | evaluation | — | — | pending maintainer review / no public endpoint |  |
 | [skill-risk-return-metrics](https://github.com/quantskills/skill-risk-return-metrics) | Calculates risk-return metrics for portfolios or strategies. | evaluation | — | — | pending maintainer review / no public endpoint |  |

--- a/README.md
+++ b/README.md
@@ -25,20 +25,20 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 以下是社区公开资产的定期快照；交互式目录见 [www.quantskills.ai](https://www.quantskills.ai/)。
 
 <!-- CATALOG:START -->
-<!-- catalog-snapshot: sha256:ecb9a3d03c6df06f3d5ca7961766ad2927ab3d370ee64e80343c0dd6946567a7 -->
+<!-- catalog-snapshot: sha256:117387f24ed230521243f50541e0d1f8c10cd949848b4ba095c55222ba833c00 -->
 <table align="center"><tr>
-<td align="center"><strong>158</strong><br><sub>资产</sub></td>
+<td align="center"><strong>156</strong><br><sub>资产</sub></td>
 <td align="center"><strong>10</strong><br><sub>分类</sub></td>
 <td align="center"><strong>1</strong><br><sub>已发布端点</sub></td>
-<td align="center"><strong>2026-08-11</strong><br><sub>快照更新</sub></td>
+<td align="center"><strong>2026-08-29</strong><br><sub>快照更新</sub></td>
 </tr></table>
 
 ## 分类总览
 - [01 数据接口与数据仓库](#cat-01) — 7 项资产（数据源与连接器 / 仓库与缓存 / 行情数据治理 / PIT 与数据质量）
-- [02 因子研发工具箱](#cat-02) — 32 项资产（因子创意 / 因子生成 / 正交与合成 / 因子筛选 / 因子评价 / 因子池与在线化）
+- [02 因子研发工具箱](#cat-02) — 31 项资产（因子创意 / 因子生成 / 正交与合成 / 因子筛选 / 因子评价 / 因子池与在线化）
 - [03 市场与标的分析](#cat-03) — 32 项资产（A 股 / 港股与美股 / ETF、基金与指数 / 期货与商品 / 期权与可转债 / 宏观与跨资产）
 - [04 风险监控与预警](#cat-04) — 19 项资产（市场状态 / 资金与拥挤 / 流动性风险 / 公司事件 / 监管合规 / 组合压力测试 / 自动预警）
-- [05 策略回测与交易工具](#cat-05) — 19 项资产（策略与信号 / 组合构建 / 回测引擎 / 绩效归因 / 交易成本 / 微观结构 / 仓位与订单 / 模拟与实盘执行）
+- [05 策略回测与交易工具](#cat-05) — 18 项资产（策略与信号 / 组合构建 / 回测引擎 / 绩效归因 / 交易成本 / 微观结构 / 仓位与订单 / 模拟与实盘执行）
 - [06 投研模型与研究复现](#cat-06) — 18 项资产（论文复现 / 策略复现 / 统计与机器学习模型 / 投资者研究模型 / 实验登记与可重复研究）
 - [07 研究验证与质量工具](#cat-07) — 11 项资产（前视与数据泄漏 / 幸存者偏差 / Walk-forward 与 OOS / 信号稳定性 / 预测校准 / 数值与模型审计 / 工作流审计）
 - [08 资讯搜索与知识分析](#cat-08) — 6 项资产（新闻与公告 / 机构研究 / 每日复盘）
@@ -87,7 +87,7 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 
 <a id="cat-02"></a>
 <details>
-<summary><strong>02 因子研发工具箱</strong> — 32 项资产，含截图 9</summary>
+<summary><strong>02 因子研发工具箱</strong> — 31 项资产，含截图 8</summary>
 
 ### 因子创意（2）
 
@@ -96,7 +96,7 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 | [skill-factor-idea-generation](https://github.com/quantskills/skill-factor-idea-generation) | 根据默认数据范围生成包含经济逻辑和风险说明的因子候选想法。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-factormad-debate-factor-mining](https://github.com/quantskills/skill-factormad-debate-factor-mining) | 参考FactorMAD多智能体辩论框架进行可解释的股票Alpha因子挖掘。 | factor-generation | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-factormad-debate-factor-mining.png"><img src="assets/skill-factormad-debate-factor-mining.png" width="260"></a> |
 
-### 因子生成（17）
+### 因子生成（16）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
@@ -116,7 +116,6 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 | [skill-overseas-equity-factor-miner](https://github.com/quantskills/skill-overseas-equity-factor-miner) | 发现并以IC、衰减和换手率验证港美股横截面alpha因子。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-quant-factor-directional-alpha](https://github.com/quantskills/skill-quant-factor-directional-alpha) | 提供用于趋势、突破和反转研究的 OHLCV 方向因子库。 | factor-generation | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-quant-factor-directional-alpha.png"><img src="assets/skill-quant-factor-directional-alpha.png" width="260"></a> |
 | [skill-quant-factor-risk-pattern-alpha](https://github.com/quantskills/skill-quant-factor-risk-pattern-alpha) | 提供用于波动、K 线形态和回撤压力研究的 OHLCV 因子库。 | factor-generation | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-quant-factor-risk-pattern-alpha.png"><img src="assets/skill-quant-factor-risk-pattern-alpha.png" width="260"></a> |
-| [skill-quant-factor-volume-stat-alpha](https://github.com/quantskills/skill-quant-factor-volume-stat-alpha) | 提供用于成交量和量价统计研究的 OHLCV 因子库。 | factor-generation | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-quant-factor-volume-stat-alpha.png"><img src="assets/skill-quant-factor-volume-stat-alpha.png" width="260"></a> |
 
 ### 正交与合成（3）
 
@@ -283,7 +282,7 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 
 <a id="cat-05"></a>
 <details>
-<summary><strong>05 策略回测与交易工具</strong> — 19 项资产，含截图 2</summary>
+<summary><strong>05 策略回测与交易工具</strong> — 18 项资产，含截图 2</summary>
 
 ### 策略与信号（4）
 
@@ -308,11 +307,10 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 | [skill-backtest](https://github.com/quantskills/skill-backtest) | 提供横截面多头回测协议，固定 T+1 开盘成交、费用、涨跌停剔除与诊断图表。 | backtesting | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-backtest.png"><img src="assets/skill-backtest.png" width="260"></a> |
 | [skill-factor-backtest](https://github.com/quantskills/skill-factor-backtest) | 对给定因子和行情数据执行long-only横截面因子回测并生成诊断报告。 | backtesting | — | — | 待维护者审核 / 无公开端点 |  |
 
-### 绩效归因（5）
+### 绩效归因（4）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
-| [skill-brinson-performance-attribution](https://github.com/quantskills/skill-brinson-performance-attribution) | 执行 Brinson-Fachler 或 BHB 归因、HHI 与贡献排序，并支持 Carino 多期链接。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-portfolio-attribution](https://github.com/quantskills/skill-portfolio-attribution) | 将组合主动收益分解为行业配置、个股选择、交互效应和因子贡献。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-portfolio-pnl-attribution](https://github.com/quantskills/skill-portfolio-pnl-attribution) | 按证券和行业归因组合已实现收益，并对账费用、基准和输入质量。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-risk-return-metrics](https://github.com/quantskills/skill-risk-return-metrics) | 计算投资组合或策略的风险收益指标。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 以下是社区公开资产的定期快照；交互式目录见 [www.quantskills.ai](https://www.quantskills.ai/)。
 
 <!-- CATALOG:START -->
-<!-- catalog-snapshot: sha256:117387f24ed230521243f50541e0d1f8c10cd949848b4ba095c55222ba833c00 -->
+<!-- catalog-snapshot: sha256:276e68899f6db4a7570a1b13cd84231f94987469343002522270686e52e87091 -->
 <table align="center"><tr>
-<td align="center"><strong>156</strong><br><sub>资产</sub></td>
+<td align="center"><strong>214</strong><br><sub>资产</sub></td>
 <td align="center"><strong>10</strong><br><sub>分类</sub></td>
 <td align="center"><strong>1</strong><br><sub>已发布端点</sub></td>
 <td align="center"><strong>2026-08-29</strong><br><sub>快照更新</sub></td>
@@ -35,14 +35,14 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 
 ## 分类总览
 - [01 数据接口与数据仓库](#cat-01) — 7 项资产（数据源与连接器 / 仓库与缓存 / 行情数据治理 / PIT 与数据质量）
-- [02 因子研发工具箱](#cat-02) — 31 项资产（因子创意 / 因子生成 / 正交与合成 / 因子筛选 / 因子评价 / 因子池与在线化）
-- [03 市场与标的分析](#cat-03) — 32 项资产（A 股 / 港股与美股 / ETF、基金与指数 / 期货与商品 / 期权与可转债 / 宏观与跨资产）
-- [04 风险监控与预警](#cat-04) — 19 项资产（市场状态 / 资金与拥挤 / 流动性风险 / 公司事件 / 监管合规 / 组合压力测试 / 自动预警）
-- [05 策略回测与交易工具](#cat-05) — 18 项资产（策略与信号 / 组合构建 / 回测引擎 / 绩效归因 / 交易成本 / 微观结构 / 仓位与订单 / 模拟与实盘执行）
-- [06 投研模型与研究复现](#cat-06) — 18 项资产（论文复现 / 策略复现 / 统计与机器学习模型 / 投资者研究模型 / 实验登记与可重复研究）
-- [07 研究验证与质量工具](#cat-07) — 11 项资产（前视与数据泄漏 / 幸存者偏差 / Walk-forward 与 OOS / 信号稳定性 / 预测校准 / 数值与模型审计 / 工作流审计）
-- [08 资讯搜索与知识分析](#cat-08) — 6 项资产（新闻与公告 / 机构研究 / 每日复盘）
-- [09 量化智能体与自动化](#cat-09) — 8 项资产（研究 Agent / 监控与风险 Agent / 交易执行 Agent / 工作流编排 Agent）
+- [02 因子研发工具箱](#cat-02) — 44 项资产（因子创意 / 因子生成 / 正交与合成 / 因子筛选 / 因子评价 / 因子池与在线化）
+- [03 市场与标的分析](#cat-03) — 44 项资产（A 股 / 港股与美股 / ETF、基金与指数 / 期货与商品 / 期权与可转债 / 宏观与跨资产）
+- [04 风险监控与预警](#cat-04) — 22 项资产（市场状态 / 资金与拥挤 / 流动性风险 / 公司事件 / 监管合规 / 组合压力测试 / 自动预警）
+- [05 策略回测与交易工具](#cat-05) — 25 项资产（策略与信号 / 组合构建 / 回测引擎 / 绩效归因 / 交易成本 / 微观结构 / 仓位与订单 / 模拟与实盘执行）
+- [06 投研模型与研究复现](#cat-06) — 30 项资产（论文复现 / 策略复现 / 统计与机器学习模型 / 投资者研究模型 / 实验登记与可重复研究）
+- [07 研究验证与质量工具](#cat-07) — 12 项资产（前视与数据泄漏 / 幸存者偏差 / Walk-forward 与 OOS / 信号稳定性 / 预测校准 / 数值与模型审计 / 工作流审计）
+- [08 资讯搜索与知识分析](#cat-08) — 10 项资产（新闻与公告 / 机构研究 / 每日复盘）
+- [09 量化智能体与自动化](#cat-09) — 14 项资产（研究 Agent / 监控与风险 Agent / 交易执行 Agent / 工作流编排 Agent）
 - [10 基础设施与模板](#cat-10) — 6 项资产（Skill 模板 / Agent 模板 / 构建与发布工具）
 
 ## 工作流地图
@@ -87,7 +87,7 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 
 <a id="cat-02"></a>
 <details>
-<summary><strong>02 因子研发工具箱</strong> — 31 项资产，含截图 8</summary>
+<summary><strong>02 因子研发工具箱</strong> — 44 项资产，含截图 8</summary>
 
 ### 因子创意（2）
 
@@ -96,23 +96,33 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 | [skill-factor-idea-generation](https://github.com/quantskills/skill-factor-idea-generation) | 根据默认数据范围生成包含经济逻辑和风险说明的因子候选想法。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-factormad-debate-factor-mining](https://github.com/quantskills/skill-factormad-debate-factor-mining) | 参考FactorMAD多智能体辩论框架进行可解释的股票Alpha因子挖掘。 | factor-generation | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-factormad-debate-factor-mining.png"><img src="assets/skill-factormad-debate-factor-mining.png" width="260"></a> |
 
-### 因子生成（16）
+### 因子生成（26）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
 | [skill-a1-lhb-tracking](https://github.com/quantskills/skill-a1-lhb-tracking) | 用龙虎榜席位历史表现和次日溢价生成事件驱动排序因子。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-alpha-a06-hotmoney-reversal](https://github.com/quantskills/skill-alpha-a06-hotmoney-reversal) | 从龙虎榜席位与行情数据计算热钱席位冷却反转因子并提供验证与回测产物。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-alpha-a3-streak-leader-relay](https://github.com/quantskills/skill-alpha-a3-streak-leader-relay) | 连板龙头接力（A3）Alpha 因子——从全 A 市场每日 ≥3 板候选池中识别 T+1 接力的事件型 top-N 信号，10 个子因子（个股截面 8 + 大盘情绪 2），权重可用 ICIR + shrinkage 重训，含滚动 IC gate 与 score 加权。研究层面的候选发现器，非交易策略。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-alpha-f1-position-change](https://github.com/quantskills/skill-alpha-f1-position-change) | 从期货前 20 席位净持仓变化计算持仓突变因子并生成信号。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-alpha-f5-member-position-concentration](https://github.com/quantskills/skill-alpha-f5-member-position-concentration) | 从机构、游资与北向等席位净持仓计算成员持仓集中度信号。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-alpha-f6-family-position-reverse](https://github.com/quantskills/skill-alpha-f6-family-position-reverse) | 从期货家族席位持仓反转关系计算交易信号。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-alpha-f8-family-main-divergence](https://github.com/quantskills/skill-alpha-f8-family-main-divergence) | 从期货家族席位与主力席位持仓背离计算因子信号。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
-| [skill-alpha-ncav-graham](https://github.com/quantskills/skill-alpha-ncav-graham) | 计算 Graham NCAV 净流动资产折价因子，面向排除金融股的 A 股深度价值筛选并生成信号。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-causal-alpha-discovery](https://github.com/quantskills/skill-causal-alpha-discovery) | Discover causal alpha factors from OHLCV data using causal discovery (PC + LiNGAM + NOTEARS), build Structural Causal Models, construct regime-invariant factor expressions, and validate through backtesting. Produces OHLCV-only alpha factors whose predictive power is grounded in causal mechanisms rather than spurious correlations. Use when an agent needs to discover stable alpha factors that survive regime changes, test whether existing factors are causal or merely correlational, or generate alpha factors with formal invariance guarantees on portable agent platforms such as Claude Code, Codex, or Codex-style skill systems. | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-doc-to-alphas](https://github.com/quantskills/skill-doc-to-alphas) | 定义OHLCV因子表达式格式和校验规则，用于从文档生成Alpha因子。 | factor-generation | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-doc-to-alphas.png"><img src="assets/skill-doc-to-alphas.png" width="260"></a> |
 | [skill-factor-alpha191-alpha101](https://github.com/quantskills/skill-factor-alpha191-alpha101) | 从长表OHLCV CSV批量计算Alpha101和Alpha191因子并输出宽表CSV。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-factor-loop-evolve](https://github.com/quantskills/skill-factor-loop-evolve) | 本地闭环因子研究系统：生成导入因子，验证，回测（PandaData真实A股数据），诊断，优化，经验记忆，生成新批次，迭代N轮，实现自我改进的因子发现与优化。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-factor-mine](https://github.com/quantskills/skill-factor-mine) | 提供从假设、实验记录到评分和接受或回滚的因子挖掘SOP。 | factor-generation | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-factor-mine.png"><img src="assets/skill-factor-mine.png" width="260"></a> |
 | [skill-factor-mining-pandaai](https://github.com/quantskills/skill-factor-mining-pandaai) | 使用PandaAI数据和分析反馈进行因子挖掘，或从公开文档提取因子。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-factor-optimize](https://github.com/quantskills/skill-factor-optimize) | 对已有股票或期货因子执行参数扫描、消融和版本增强。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-fundamental-alpha](https://github.com/quantskills/skill-fundamental-alpha) | 基于基本面数据（PandaData）生成Alpha因子表达式，支持从研报/自然语言输入中提取估值、质量、成长、现金流、预期与股东信号，并通过公式合约与PIT面板验证。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-fundamental-factor-analysis](https://github.com/quantskills/skill-fundamental-factor-analysis) | 从季度财报计算并验证A股估值、质量和成长因子。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-futures-transition-crowding-factor](https://github.com/quantskills/skill-futures-transition-crowding-factor) | 从期货合约迁移与拥挤转移构造可审计横截面因子 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-graph-spectral-diffusion-factor](https://github.com/quantskills/skill-graph-spectral-diffusion-factor) | 在点时股票关系图上构造可审计的因子扩散与局部残差 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-hk-us-fundamental-factor](https://github.com/quantskills/skill-hk-us-fundamental-factor) | Build, standardize, compare, and validate multi-factor fundamental panels for Hong Kong and US equities from PandaAI operating, market-financial, industry-median, price-volume, and financial-statement APIs. Use for quality, value, growth, momentum, low-risk, composite-score, percentile-rank, or cross-market stock-screening tasks. | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-llm-alpha-generator](https://github.com/quantskills/skill-llm-alpha-generator) | Mine formulaic alpha factors end to end: LLM 主导生成候选公式 → 三层校验（白名单/量纲/前视）→ warm-start 遗传编程精修 → AlphaEval 五维打分 → LLM 经济解释 → 自包含 HTML 报告，返回结构化因子结果。Use when the user wants to mine/discover alpha factors, generate formulaic (expression-tree) trading factors, run LLM+GP factor search, or evaluate factor predictive power (RankIC) on stocks or futures. 只挖因子、不做回测（回测归另一 skill）。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-material-contract-alpha](https://github.com/quantskills/skill-material-contract-alpha) | A 股重大合同 Alpha 因子：基于合同金额对数和的横截面排序信号。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-minuteflow-alpha](https://github.com/quantskills/skill-minuteflow-alpha) | 基于分钟级行情数据（PandaData）生成Alpha因子表达式，支持从研报/自然语言输入中提取日内微观结构信号（VWAP偏离、订单流代理、日内动量衰减、波动率曲线等），并通过公式合约验证。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-optimal-transport-cross-sectional-factor](https://github.com/quantskills/skill-optimal-transport-cross-sectional-factor) | 用点时截面分布的单调最优传输构造可审计因子 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-overseas-equity-factor-miner](https://github.com/quantskills/skill-overseas-equity-factor-miner) | 发现并以IC、衰减和换手率验证港美股横截面alpha因子。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-quant-factor-directional-alpha](https://github.com/quantskills/skill-quant-factor-directional-alpha) | 提供用于趋势、突破和反转研究的 OHLCV 方向因子库。 | factor-generation | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-quant-factor-directional-alpha.png"><img src="assets/skill-quant-factor-directional-alpha.png" width="260"></a> |
 | [skill-quant-factor-risk-pattern-alpha](https://github.com/quantskills/skill-quant-factor-risk-pattern-alpha) | 提供用于波动、K 线形态和回撤压力研究的 OHLCV 因子库。 | factor-generation | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-quant-factor-risk-pattern-alpha.png"><img src="assets/skill-quant-factor-risk-pattern-alpha.png" width="260"></a> |
@@ -133,15 +143,18 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 | [skill-factor-ranking-sage](https://github.com/quantskills/skill-factor-ranking-sage) | 在本地因子和标签数据上运行mRMR或Marginal-SAGE并输出Top-K排名。 | factor-screening | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-residual-guided-factor-selection](https://github.com/quantskills/skill-residual-guided-factor-selection) | 使用残差 IC 和样本外评估筛选因子组合。 | factor-screening | — | — | 待维护者审核 / 无公开端点 |  |
 
-### 因子评价（5）
+### 因子评价（8）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
 | [skill-build-b10-factor-evaluation](https://github.com/quantskills/skill-build-b10-factor-evaluation) | 评估因子的 IC、IR、分层回测、单调性、换手率和衰减表现。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-factor-evaluate](https://github.com/quantskills/skill-factor-evaluate) | 对单个截面因子计算IC、夏普、回撤、单调性和换手的综合评分。 | evaluation | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-factor-evaluate.png"><img src="assets/skill-factor-evaluate.png" width="260"></a> |
+| [skill-factor-ic-decay](https://github.com/quantskills/skill-factor-ic-decay) | 用日度截面 Spearman IC、ICIR、Newey-West 显著性、滚动稳定性与多周期半衰期，诊断因子预测力衰减；事实优先，不给买卖指令。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-factor-mason](https://github.com/quantskills/skill-factor-mason) | 检查单因子研究中的时点、IC/IR、成本和中性化质量。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-factor-review](https://github.com/quantskills/skill-factor-review) | 扫描因子库和实验日志，生成量化盘点、结构分析和研究建议。 | evaluation | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-factor-review.png"><img src="assets/skill-factor-review.png" width="260"></a> |
+| [skill-futures-cta-alpha](https://github.com/quantskills/skill-futures-cta-alpha) | Commodity-futures CTA factor library — computes a structured date×variety factor panel (time-series & cross-sectional momentum, carry/roll, term structure, positioning/COT, inventory, volatility). Use when the user asks for 商品期货因子、 CTA 信号、动量/carry/期限结构/库存/持仓因子, a factor panel for futures backtesting, or futures factor IC. Fills the ecosystem gap of ZERO futures factor libraries (vs 10 for equities). Emits factor values for the factor toolchain (factor-evaluate / ic-analysis / backtest), NOT human-readable reports. | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-ic-analysis](https://github.com/quantskills/skill-ic-analysis) | 评估量化因子的IC、分组表现和预测有效性。 | evaluation | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-ic-analysis.png"><img src="assets/skill-ic-analysis.png" width="260"></a> |
+| [skill-quant-strategy-diagnostics](https://github.com/quantskills/skill-quant-strategy-diagnostics) | 检查策略或因子近期是否恶化，列出收益、IC、回撤、换手率和市场状态方面的证据。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 
 ### 因子池与在线化（2）
 
@@ -154,21 +167,29 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 
 <a id="cat-03"></a>
 <details>
-<summary><strong>03 市场与标的分析</strong> — 32 项资产，含截图 4</summary>
+<summary><strong>03 市场与标的分析</strong> — 44 项资产，含截图 4</summary>
 
-### A 股（7）
+### A 股（15）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
+| [skill-a-share-market-participation](https://github.com/quantskills/skill-a-share-market-participation) | Analyze A-share cross-sectional market participation, turnover concentration, liquidity distribution, speculative crowding, leader dependence, and structural fragility from daily or intraday stock snapshots. Use when the user asks in Chinese or English to analyze A-share market breadth, participation, turnover concentration, crowding, whether an index rally is broad or narrow, or to generate a reproducible market-structure report. Use only bundled scripts with PandaData as the primary live source, AKShare as fallback, or user-provided local data; never search, browse, or scrape webpages for replacement market data, and fail closed when approved sources are unavailable. Do not use for order routing, fill simulation, slippage/TCA, live trade execution, or stock-level margin/northbound/block-trade capital-flow attribution. | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-a-share-stock-dossier](https://github.com/quantskills/skill-a-share-stock-dossier) | 输入一个 A 股代码，汇总基本面、公司行动、股东行为、事件风险与资金面的可溯源尽调报告。 | reporting | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-a-share-stock-dossier.png"><img src="assets/skill-a-share-stock-dossier.png" width="260"></a> |
+| [skill-a-share-tradability-auditor](https://github.com/quantskills/skill-a-share-tradability-auditor) | A 股可交易性约束审计：把回测交易流放回历史行情，逐笔判定涨跌停封板、停牌、T+1、 裸卖空、新股窗口与参与率上限，把账面收益拆成"可成交收益"与"幽灵收益"， 并定位到具体交易。回答"这条净值曲线里有多少是市场根本不会给你的"。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-buffett-moat-screener](https://github.com/quantskills/skill-buffett-moat-screener) | 按巴菲特式护城河、估值和点时数据筛选 A 股与美股公司并生成研究记录。 | modeling | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-buffett-moat-screener--lavineversion](https://github.com/quantskills/skill-buffett-moat-screener--lavineversion) | 基于 PandaData 点时证据执行十年资本回报与护城河硬筛选。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-concept-rotation-monitor](https://github.com/quantskills/skill-concept-rotation-monitor) | 监测 A 股概念与题材的动量、宽度和轮动变化并生成研究报告。 | monitoring | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-dividend-yield-scan](https://github.com/quantskills/skill-dividend-yield-scan) | 计算A股滚动股息率、连续分红和除权除息日历。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-equity-placard-watchlist](https://github.com/quantskills/skill-equity-placard-watchlist) | 举牌行为监控——侦测 A 股股东持股比例上穿 5%/10%/15%/20%/25%/30% 法定披露梯度的权益变动事件，含举牌梯度、意图倾向（财务 vs 战略）、6 个月锁定期、逼近举牌线观察名单。剔除通道账户与股本稀释造成的假举牌。BUILD 型 skill，可被复盘 agent 或事件驱动 Alpha 调用。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-graham-netnet-screener](https://github.com/quantskills/skill-graham-netnet-screener) | 当需要开发、计算、验证 Graham 净净营运资本(NCAV) 因子时，使用此 skill。适用于 A 股全市场深度价值筛选，排除银行/房地产/非银金融，计算 NCAV 折价因子并生成 buy/sell/hold 信号。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-holder-structure-scan](https://github.com/quantskills/skill-holder-structure-scan) | 跟踪A股股东户数、前十大持股和自由流通股以评估筹码集中度。 | monitoring | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-post-market-screener](https://github.com/quantskills/skill-post-market-screener) | 收盘后结合技术形态和资金流筛选 A 股股票并生成报告。 | factor-screening | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-soros-reflexivity-detector](https://github.com/quantskills/skill-soros-reflexivity-detector) | 索罗斯反身性识别器——用双环模型（快环情绪-资金 / 慢环基本面-资本）判断 A 股"这波涨跌是不是自我强化的反身性、转到哪一圈、燃料和裂缝在哪"，做阶段识别与仓位纪律。BUILD 型 skill，可被复盘 agent 或 Alpha 调用。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-stock-score](https://github.com/quantskills/skill-stock-score) | skill stock score | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-stock-screener](https://github.com/quantskills/skill-stock-screener) | 依据自然语言筛选条件和 Pandadata 证据筛选 A 股股票。 | factor-screening | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-stock-screener.png"><img src="assets/skill-stock-screener.png" width="260"></a> |
+| [skill-templeton-global-contrarian](https://github.com/quantskills/skill-templeton-global-contrarian) | 当需要开发、计算、验证 Templeton 全球价值多因子 V2 时，使用此 skill。适用于 A 股/港股/美股跨市场价值筛选，基于 EP/BP/SP/股息/ROE/杠杆/动量 七子因子截面打分，生成 buy/sell/hold 信号。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 
-### 港股与美股（9）
+### 港股与美股（10）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
@@ -178,6 +199,7 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 | [skill-hk-us-consensus-revision-radar](https://github.com/quantskills/skill-hk-us-consensus-revision-radar) | 组织港美股目标价和评级的跨期修订轨迹，并生成研究报告。 | monitoring | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-hk-us-dividend-events](https://github.com/quantskills/skill-hk-us-dividend-events) | 基于Pandadata外盘接口生成港股和美股分红事件报告。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-hk-us-insider-radar](https://github.com/quantskills/skill-hk-us-insider-radar) | 扫描港股和美股内部人交易、净买卖方向、聚集交易及持股变化。 | monitoring | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-hk-us-institutional-concentration](https://github.com/quantskills/skill-hk-us-institutional-concentration) | Build, compare, and validate institutional ownership structure panels for Hong Kong and US equities with PandaAI investor concentration, ranking, and shareholder-report APIs. Use for ownership breadth, top-holder dominance, HHI, controlling-holder risk, evidence confidence, or within-market institutional ownership screening. | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-hk-us-quote-scan](https://github.com/quantskills/skill-hk-us-quote-scan) | 生成港美股行情、流动性、估值和行业相对位置的研究快照。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-stock-memory-analyzer-usa](https://github.com/quantskills/skill-stock-memory-analyzer-usa) | 对美国存储芯片股票开展多维度研究分析。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-us-sector-rotation](https://github.com/quantskills/skill-us-sector-rotation) | 生成美国行业表现、估值和轮动的事实性报告。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
@@ -191,13 +213,15 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 | [skill-index-rebalance-event-study](https://github.com/quantskills/skill-index-rebalance-event-study) | 围绕指数纳入、剔除和权重调整公告或生效日运行可复现事件研究。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-index-valuation-rotation](https://github.com/quantskills/skill-index-valuation-rotation) | 分析A股指数估值分位、行业相对估值和轮动线索。 | reporting | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-index-valuation-rotation.png"><img src="assets/skill-index-valuation-rotation.png" width="260"></a> |
 
-### 期货与商品（6）
+### 期货与商品（8）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
 | [skill-ag-futures-seasonality](https://github.com/quantskills/skill-ag-futures-seasonality) | 从农产品期货日线计算各月份历史季节性并叠加作物日历生成可视化报告。 | modeling | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-commodity-carry-cta](https://github.com/quantskills/skill-commodity-carry-cta) | 构建商品期货 carry、时序动量、横截面动量、基差动量和库存因子并回测轮动。 | factor-generation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-futures-deepview-analyst](https://github.com/quantskills/skill-futures-deepview-analyst) | 将期货DeepView自然语言请求转为数据调用计划和事实与推断分离的报告。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-futures-hedgecraft](https://github.com/quantskills/skill-futures-hedgecraft) | 当需要设计、审查或排错期货对冲、期货仓位 sizing、合约移仓、基差/carry 分析、日历价差、保证金压力测试或 CTA 风格期货配置时，使用此 skill。适用于股指期货、商品期货、利率期货和跨期价差场景，重点处理合约乘数、名义本金、保证金、期限结构、交割规则和压力损失。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-futures-investment-council](https://github.com/quantskills/skill-futures-investment-council) | Futures research Skill for analyzing, comparing, and screening futures markets with technical indicators, futures structure, and committee-style reports. Use when Codex needs to analyze a futures symbol, compare futures symbols, screen futures candidates, explain signal changes, or generate a structured futures research report without stock analysis, auto-trading, or deterministic buy/sell promises. | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-global-commodity-term-structure](https://github.com/quantskills/skill-global-commodity-term-structure) | 用公开数据研究海外商品期货期限结构、展期收益和价差。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-oil-brief](https://github.com/quantskills/skill-oil-brief) | 整合期货、EIA、OPEC和市场数据生成中文原油简报。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-xingtai-catcher](https://github.com/quantskills/skill-xingtai-catcher) | 根据文字或图像描述检索相似的 A 股和期货 K 线形态。 | factor-screening | — | — | 待维护者审核 / 无公开端点 |  |
@@ -210,19 +234,20 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 | [skill-option-strategy-builder](https://github.com/quantskills/skill-option-strategy-builder) | 构建期权策略腿组合、损益图、盈亏平衡、希腊字母和保证金分析。 | portfolio-construction | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-options-vol-analyst](https://github.com/quantskills/skill-options-vol-analyst) | 分析期权链、隐含与历史波动率、期限结构、偏度和波动率溢价。 | modeling | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-options-vol-analyst.png"><img src="assets/skill-options-vol-analyst.png" width="260"></a> |
 
-### 宏观与跨资产（3）
+### 宏观与跨资产（4）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
 | [skill-global-macro-rates-fx-lab](https://github.com/quantskills/skill-global-macro-rates-fx-lab) | 以公开利率、央行和外汇数据生成可溯源的全球宏观格局简报。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-macro-altdata-nowcast](https://github.com/quantskills/skill-macro-altdata-nowcast) | 利用宏观另类高频数据进行行业景气度现在预测和趋势观察。 | modeling | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-macro-futures-scenario-analysis](https://github.com/quantskills/skill-macro-futures-scenario-analysis) | 基于 PandaData 的宏观事件—期货预期分析：读取宏观经济日历的实际值、市场预期与前值，结合期货价格、成交量、持仓量、基差、期限结构、库存与仓单，对沪金、沪铜、原油及用户指定品种输出基准、偏强、偏弱情景。当用户询问「美国CPI对期货影响」「宏观事件期货预期」「美联储对商品影响」「期货供需与宏观共振」「事件公布前情景」时触发。仅作条件化研究，不承诺涨跌或生成自动交易指令。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-macro-monitor](https://github.com/quantskills/skill-macro-monitor) | 监测宏观数据、行业景气、经济日历和周期性宏观变化。 | monitoring | — | — | 待维护者审核 / 无公开端点 |  |
 
 </details>
 
 <a id="cat-04"></a>
 <details>
-<summary><strong>04 风险监控与预警</strong> — 19 项资产，含截图 1</summary>
+<summary><strong>04 风险监控与预警</strong> — 22 项资产，含截图 1</summary>
 
 ### 市场状态（1）
 
@@ -255,17 +280,20 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 | [skill-klarman-special-situations](https://github.com/quantskills/skill-klarman-special-situations) | 按特殊情况投资框架研究定增解禁、重组、分拆和困境反转事件。 | modeling | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-refinancing-monitor](https://github.com/quantskills/skill-refinancing-monitor) | 跟踪 A 股再融资生命周期、定价和稀释风险。 | monitoring | — | — | 待维护者审核 / 无公开端点 |  |
 
-### 监管合规（2）
+### 监管合规（3）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
 | [skill-audit-opinion-scanner](https://github.com/quantskills/skill-audit-opinion-scanner) | 从审计意见、财务报表和行业对标评估 A 股财务健康并输出风险检查结果。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-csrc-approval-pipeline](https://github.com/quantskills/skill-csrc-approval-pipeline) | A 股证监会批文进度追踪：按公告级别分类、审批流程监控、批文状态报告生成。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-regulatory-risk-radar](https://github.com/quantskills/skill-regulatory-risk-radar) | 汇总 A 股监管与合规风险事件并进行分级。 | monitoring | — | — | 待维护者审核 / 无公开端点 |  |
 
-### 组合压力测试（4）
+### 组合压力测试（6）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
+| [skill-derivatives-pricing-stochastic-calculus](https://github.com/quantskills/skill-derivatives-pricing-stochastic-calculus) | 输入期权合约与市场参数，输出可复现的定价与风险报告：BSM 解析价、全套希腊字母、二叉树与蒙特卡洛数值价、隐含波动率、平价与无套利校验，一次算清。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-guarantee-risk-scan](https://github.com/quantskills/skill-guarantee-risk-scan) | A 股累计担保风险扫描：担保比率、超额担保、高负债率担保占比监控与预警报告。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-portfolio-checkup](https://github.com/quantskills/skill-portfolio-checkup) | 汇总持仓集中度、基准偏离、估值、质量和风险暴露生成组合健康报告。 | risk | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-quant-portfolio-risk](https://github.com/quantskills/skill-quant-portfolio-risk) | 分析组合风险暴露、约束和压力情景。 | risk | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-risk-model](https://github.com/quantskills/skill-risk-model) | 构建多因子风险模型并进行风险归因。 | risk | — | — | 待维护者审核 / 无公开端点 |  |
@@ -282,7 +310,7 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 
 <a id="cat-05"></a>
 <details>
-<summary><strong>05 策略回测与交易工具</strong> — 18 项资产，含截图 2</summary>
+<summary><strong>05 策略回测与交易工具</strong> — 25 项资产，含截图 2</summary>
 
 ### 策略与信号（4）
 
@@ -293,12 +321,17 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 | [skill-oversold-rebound](https://github.com/quantskills/skill-oversold-rebound) | 判断A股短期超跌反弹环境并筛选候选股票。 | factor-screening | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-qbti](https://github.com/quantskills/skill-qbti) | 通过五部分问答将用户偏好转换为因子方向和策略参数。 | portfolio-construction | — | — | 待维护者审核 / 无公开端点 |  |
 
-### 组合构建（2）
+### 组合构建（7）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
 | [skill-dalio-all-weather](https://github.com/quantskills/skill-dalio-all-weather) | 针对A股股票、债券、黄金和商品资产提供全天候配置与回测流程。 | portfolio-construction | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-portfolio-blacklitterman](https://github.com/quantskills/skill-portfolio-blacklitterman) | Black-Litterman 组合优化 —— 用户问「跑一下 BL 组合」「基于视图的组合权重」「相对沪深300 的主动配置」「动量/反转/换手视图对权重的影响」类问题时触发。以沪深300 指数权重为先验，用动量/反转/换手率三条因子视图更新，输出长权重组合，按「样式② 结构化播报」呈现给用户。 | risk | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-portfolio-cvar-optim](https://github.com/quantskills/skill-portfolio-cvar-optim) | 当需要开发、计算、验证 CVaR 尾部风险最小化组合时，使用此 skill。在预期收益约束下最小化组合 95% CVaR，支持极值理论(EVT/GPD)尾部补样、组合权重求解、样本外验证。 | risk | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-portfolio-optimize](https://github.com/quantskills/skill-portfolio-optimize) | 将alpha信号转为受权重、行业、暴露和换手约束的优化组合权重。 | portfolio-construction | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-portfolio-risk-parity](https://github.com/quantskills/skill-portfolio-risk-parity) | 当需要开发、计算、验证风险平价（等风险贡献 ERC）组合时使用。手写 Ledoit-Wolf 收缩协方差稳定相关性，scipy SLSQP 求 ERC 权重，支持指数/期货/ETF 三类资产与月度 rebalance。 | risk | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-rl-portfolio-allocator](https://github.com/quantskills/skill-rl-portfolio-allocator) | skill rl portfolio allocator | risk | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-signal-portfolio-optimize](https://github.com/quantskills/skill-signal-portfolio-optimize) | 将单个股票信号转换为受基准相对风险、风格、行业、换手和成本约束的可审计组合权重。 | portfolio-construction | — | — | 待维护者审核 / 无公开端点 |  |
 
 ### 回测引擎（2）
 
@@ -316,17 +349,19 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 | [skill-risk-return-metrics](https://github.com/quantskills/skill-risk-return-metrics) | 计算投资组合或策略的风险收益指标。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-strategy-tearsheet-report](https://github.com/quantskills/skill-strategy-tearsheet-report) | 生成包含风险调整指标的策略绩效 tearsheet。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 
-### 交易成本（2）
+### 交易成本（3）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
+| [skill-strategy-capacity-tca](https://github.com/quantskills/skill-strategy-capacity-tca) | 用成交与 ADV 估计参与率、平方根/线性冲击成本与容量曲线，回答「策略能承载多少资金、成本何时吃掉 alpha」——估计非保证，不作交易建议。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-transaction-cost-analysis](https://github.com/quantskills/skill-transaction-cost-analysis) | 将成交记录相对 VWAP/TWAP 分解为多类交易成本。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-transaction-cost-calibration](https://github.com/quantskills/skill-transaction-cost-calibration) | 从成交和市场数据校准佣金、价差、滑点与冲击成本假设。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 
-### 微观结构（1）
+### 微观结构（2）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
+| [skill-microstructure-vwap-deviation](https://github.com/quantskills/skill-microstructure-vwap-deviation) | Minute-bar VWAP deviation strategy research and auditable SSQuant futures validation. Use for rolling VWAP deviation signals, confirmed mean reversion, trend guards, next-bar execution, execution-cost modeling, frozen-data backtests, and trade-result review. | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-quant-execution-microstructure](https://github.com/quantskills/skill-quant-execution-microstructure) | 将已批准的交易目标转化为可观测的成本感知执行方案。 | execution | — | — | 待维护者审核 / 无公开端点 |  |
 
 ### 仓位与订单（2）
@@ -346,14 +381,13 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 
 <a id="cat-06"></a>
 <details>
-<summary><strong>06 投研模型与研究复现</strong> — 18 项资产，含截图 7</summary>
+<summary><strong>06 投研模型与研究复现</strong> — 30 项资产，含截图 6</summary>
 
-### 论文复现（2）
+### 论文复现（1）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
 | [skill-paper-replication](https://github.com/quantskills/skill-paper-replication) | 支持论文检索、数据提取、实验复现和研究结果报告。 | modeling | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-paper-replication.png"><img src="assets/skill-paper-replication.png" width="260"></a> |
-| [skill-quant-research-replication](https://github.com/quantskills/skill-quant-research-replication) | 指导可审计的量化研究复现流程。 | modeling | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-quant-research-replication.png"><img src="assets/skill-quant-research-replication.png" width="260"></a> |
 
 ### 策略复现（1）
 
@@ -361,27 +395,40 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 |---|---|---|---|---|---|---|
 | [skill-report-replication](https://github.com/quantskills/skill-report-replication) | 指导将研究报告转化为可复现的分析流程。 | modeling | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-report-replication.png"><img src="assets/skill-report-replication.png" width="260"></a> |
 
-### 统计与机器学习模型（6）
+### 统计与机器学习模型（11）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
+| [skill-dl-autoencoder-anomaly](https://github.com/quantskills/skill-dl-autoencoder-anomaly) | 深度自编码器无监督异常检测 —— 用户问「今天哪些股票走势最异常」「沪深300 异常股」「AE 跑一下」「找不像自己往常样子的股票」类问题时触发。对沪深300成分股用最近60日窗口重训一个MLP自编码器，输出T日重建误差Top-10异常股，按「样式② 结构化播报」呈现。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-dl-gnn-stock-graph](https://github.com/quantskills/skill-dl-gnn-stock-graph) | 构建A股多层异构图并使用图神经网络进行量化选股与回测。 | modeling | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-dl-tcn-shortterm](https://github.com/quantskills/skill-dl-tcn-shortterm) | 使用因果扩张 Temporal Convolutional Network 对沪深 A 股分钟线执行未来 1、2、3、5 个交易日的横截面收益排序研究，并以同数据、切分和预算的 LSTM 作为基准，生成可审计的数据、训练、速度和预测效果证据。用于运行或诊断 TCN 短线预测、核验感受野与因果卷积、PIT/walk-forward/purge/embargo、防止未来泄漏、比较 RankIC/Top 区域指标与训练吞吐，或判断研究模型是否达到冻结候选条件；不用于组合换手优化、券商连接、实盘交易或收益承诺。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-dl-transformer-multiasset](https://github.com/quantskills/skill-dl-transformer-multiasset) | skill dl transformer multiasset | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-llm-rag-financial-qa](https://github.com/quantskills/skill-llm-rag-financial-qa) | 财报公告 RAG 问答系统——就一家 A 股公司的财报/公告提问，给出带官方引用、可核对、拒绝编造的回答。三路路由（数字精确算 / 底仓文本检索 / 官方全文按需）+ 引用纪律 + 拒答。数据源 PandaData 优先、官方披露网页为次级源。BUILD 型 skill，可被复盘 agent 或投研 agent 调用。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-ml-purged-cv](https://github.com/quantskills/skill-ml-purged-cv) | 审计任意金融特征、可训练时序模型或候选策略收益，并执行防泄漏的 Purged K-Fold、Embargo、CPCV、Causal Walk-Forward、PBO、DSR、Governed Holdout 与 Temporal Forward Evidence。用于检查未来函数、信息区间重叠、特征可用时间和血缘、Fold-Local 预处理、CPCV Path 稳健性、策略选择过拟合、预测是否在标签成熟前登记，以及在接受金融模型或策略前生成结构化验证证据。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-model-hpo-evidence-driven](https://github.com/quantskills/skill-model-hpo-evidence-driven) | 以固定验证流程和试验级证据优化量化多因子模型超参数。 | modeling | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-pair-correlation](https://github.com/quantskills/skill-pair-correlation) | 计算和解释资产对的相关性、滚动关系及其研究用途。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-simons-pairs-trading](https://github.com/quantskills/skill-simons-pairs-trading) | 研究 A 股配对交易的协整、价差和执行约束。 | modeling | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-statistical-arbitrage-time-series](https://github.com/quantskills/skill-statistical-arbitrage-time-series) | 构建统计套利时间序列研究并生成可追溯报告。 | modeling | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-time-series-analysis](https://github.com/quantskills/skill-time-series-analysis) | 对金融时间序列进行诊断并生成分析报告。 | modeling | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-time-series-analysis.png"><img src="assets/skill-time-series-analysis.png" width="260"></a> |
 
-### 投资者研究模型（7）
+### 投资者研究模型（15）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
+| [skill-ah-share-relative-value-montior](https://github.com/quantskills/skill-ah-share-relative-value-montior) | 监控A/H双重上市股票的汇率调整溢价、历史极值、脱钩与日频价格发现关系。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-etf-flow-radar](https://github.com/quantskills/skill-etf-flow-radar) | 每日盘后 ETF 资金流雷达 —— 用户问「今天/最近 ETF 有什么异动」「ETF 资金流看下」「哪些 ETF 在被大量申购/赎回」「ETF 净申赎异动」类问题时触发。扫描主流权益 ETF，输出三类信号（净申赎异动 / 折溢价背离 / 连续多日大额同向），以「样式② 结构化播报」呈现给用户。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-gaetano-crux-capital-research-model](https://github.com/quantskills/skill-gaetano-crux-capital-research-model) | 以公开资料拆解光子、光网络和AI基础设施公司的研究证据与风险。 | modeling | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-gaetano-crux-capital-research-model.png"><img src="assets/skill-gaetano-crux-capital-research-model.png" width="260"></a> |
 | [skill-gao-shanwen-research-model](https://github.com/quantskills/skill-gao-shanwen-research-model) | 整理、检索和学习高善文公开著作与文章。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-investment-decision](https://github.com/quantskills/skill-investment-decision) | 整合研究证据、估值和风险信息，形成可追溯的投资决策报告。 | modeling | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-keynes-contrarian-investment](https://github.com/quantskills/skill-keynes-contrarian-investment) | 运用长期预期和反共识框架识别过度乐观、悲观及价值陷阱。 | modeling | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-kline-pattern-vision](https://github.com/quantskills/skill-kline-pattern-vision) | 用截图或只读 PandaData 行情识别股票/期货K线趋势结构、蜡烛线和候选图表形态，支持日线与1/5/10/15/30/60分钟线，输出证据、确认条件、失效条件和不确定性。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-munger-mental-model](https://github.com/quantskills/skill-munger-mental-model) | 运用多元思维模型框架生成公司投资研究和判断报告。 | modeling | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-performance-attribution](https://github.com/quantskills/skill-performance-attribution) | A股量化策略绩效归因：三层综合归因（Alpha/Beta/择时 + Brinson 配置/选择/交互 + 因子收益归因含风格行业与 Alpha 残差），输出统一归因报告并做分解对账。与 skill-risk-model（风险归因）互补。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-rotation-radar](https://github.com/quantskills/skill-rotation-radar) | 当需要分析市场状态、行业轮动、ETF 强弱排序、市场宽度、风格切换或战术配置信号时，使用此 skill。适用于 A 股、港股、美股和 ETF 池的行业轮动分析、risk-on/risk-off 状态识别、相对强弱排名、宽度确认、假突破过滤和轮动失效条件设计。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-serenity-research-model](https://github.com/quantskills/skill-serenity-research-model) | 从公开 X/Twitter 证据重建 Serenity 风格的研究逻辑。 | modeling | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-serenity-research-model.png"><img src="assets/skill-serenity-research-model.png" width="260"></a> |
+| [skill-shortterm-mean-reversal](https://github.com/quantskills/skill-shortterm-mean-reversal) | A 股五交易日收益率横截面反转因子与成本敏感回测。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-tqx-research](https://github.com/quantskills/skill-tqx-research) | skill tqx research | reporting | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-trendline-breakdown-reversal](https://github.com/quantskills/skill-trendline-breakdown-reversal) | 计算A股日线下跌突破划线压力位反转因子，识别下破下降压力线后反转确认的个股；当用户提供交易日期、要求自动获取当日全市场A股行情、量化选股、因子研究或回测时使用。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-x-trader-builder](https://github.com/quantskills/skill-x-trader-builder) | 从公开 X/Twitter 帖子数据构建交易者专属研究模型技能。 | orchestration | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-x-trader-builder.png"><img src="assets/skill-x-trader-builder.png" width="260"></a> |
 
 ### 实验登记与可重复研究（2）
@@ -395,7 +442,7 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 
 <a id="cat-07"></a>
 <details>
-<summary><strong>07 研究验证与质量工具</strong> — 11 项资产，含截图 1</summary>
+<summary><strong>07 研究验证与质量工具</strong> — 12 项资产，含截图 1</summary>
 
 ### 前视与数据泄漏（2）
 
@@ -437,22 +484,25 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 |---|---|---|---|---|---|---|
 | [skill-factor-debug](https://github.com/quantskills/skill-factor-debug) | 提供按症状、病因和验证手段组织的因子失效诊断手册。 | evaluation | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-factor-debug.png"><img src="assets/skill-factor-debug.png" width="260"></a> |
 
-### 工作流审计（1）
+### 工作流审计（2）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
+| [skill-backtest-assumption_check](https://github.com/quantskills/skill-backtest-assumption_check) | 独立的回测假设审计师：对回测代码/策略代码/研究报告按九大维度（成交时点、成本、涨跌停停牌、幸存者、多重比较、数据对齐、换手容量、基准、透明）逐条取证，输出缺陷×证据×严重度×影响×修复清单，配套可运行校验脚本。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-pandaai-workflow-audit](https://github.com/quantskills/skill-pandaai-workflow-audit) | 审计PandaAI工作流的图结构、代码、时序、参数和回测验证证据。 | evaluation | — | — | 待维护者审核 / 无公开端点 |  |
 
 </details>
 
 <a id="cat-08"></a>
 <details>
-<summary><strong>08 资讯搜索与知识分析</strong> — 6 项资产，含截图 1</summary>
+<summary><strong>08 资讯搜索与知识分析</strong> — 10 项资产，含截图 1</summary>
 
-### 新闻与公告（3）
+### 新闻与公告（5）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
+| [skill-disclosure-event-extractor](https://github.com/quantskills/skill-disclosure-event-extractor) | Turn unstructured A-share disclosure text from cninfo (巨潮) and the SSE/SZSE exchanges into a traceable, structured event table (监管问询/诉讼担保/重组/治理/ 停牌控制权变更/增减持/质押/业绩预告). Use when the user asks to scan A-share announcements, find 关注函/问询函/诉讼/停牌/易主 events, build an event table for factor or alert pipelines, or backtest disclosure events. Fills the information-search gap Pandadata does not cover. | reporting | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-earnings-event-study](https://github.com/quantskills/skill-earnings-event-study) | 对财报/公司事件做正式 CAR 事件研究：异常收益、多窗口累计异常收益、截面 t 检验与符号检验；披露样本量与模型，不输出买卖建议。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-earnings-season-tracker](https://github.com/quantskills/skill-earnings-season-tracker) | 在财报季扫描业绩预告、行业分布和审计非标事项。 | monitoring | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-fin-news](https://github.com/quantskills/skill-fin-news) | 聚合财经快讯和市场数据，精选头条并撰写分析文章。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-news-sentiment-analyst](https://github.com/quantskills/skill-news-sentiment-analyst) | 采集、核验并分析A股财经新闻情绪，生成研究报告。 | modeling | — | — | 待维护者审核 / 无公开端点 |  |
@@ -463,32 +513,39 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 |---|---|---|---|---|---|---|
 | [skill-institutional-research-tracker](https://github.com/quantskills/skill-institutional-research-tracker) | 监测A股机构调研活动、关注度及其变化。 | monitoring | — | — | 待维护者审核 / 无公开端点 |  |
 
-### 每日复盘（2）
+### 每日复盘（4）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
 | [skill-daily-report](https://github.com/quantskills/skill-daily-report) | 汇总多个市场的行情、板块、资金和新闻数据，生成每日 Markdown 复盘报告。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [skill-market-daily-review](https://github.com/quantskills/skill-market-daily-review) | 生成基于Pandadata的A股收盘后每日市场复盘报告。 | reporting | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/skill-market-daily-review.png"><img src="assets/skill-market-daily-review.png" width="260"></a> |
+| [skill-strategy-performance-report](https://github.com/quantskills/skill-strategy-performance-report) | Use when an agent needs to generate a periodic performance report for a LIVE A-share quant strategy — 日报/周报/月报/半年报/年报 or custom period — covering returns, risk, trade analysis, and position/turnover detail, with embedded visualizations. Outputs a self-contained offline HTML dashboard (interactive ECharts) plus Markdown + JSON. | reporting | — | — | 待维护者审核 / 无公开端点 |  |
+| [skill-trade-review](https://github.com/quantskills/skill-trade-review) | 把交易流水转成结构化复盘结果，包含归因、逐笔点评、错误模式、建议和可选 LLM 总结。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 
 </details>
 
 <a id="cat-09"></a>
 <details>
-<summary><strong>09 量化智能体与自动化</strong> — 8 项资产，含截图 5</summary>
+<summary><strong>09 量化智能体与自动化</strong> — 14 项资产，含截图 5</summary>
 
-### 研究 Agent（2）
+### 研究 Agent（3）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
 | [agent-correlation-break-research](https://github.com/quantskills/agent-correlation-break-research) | 用 Pandadata 多资产收益相关性变化识别风格切换、分散化压力与结构性行情。 | monitoring | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/agent-correlation-break-research.png"><img src="assets/agent-correlation-break-research.png" width="260"></a> |
+| [agent-feng-reverse](https://github.com/quantskills/agent-feng-reverse) | 追踪微博"峰哥亡命天涯"的发言，提取股票/市场观点，生成反向操作信号。峰哥是A股知名反向指标，其公开观点具有稳定的反向参考价值。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [agent-macro-driven-rotation](https://github.com/quantskills/agent-macro-driven-rotation) | 以改进美林时钟定相、景气 Nowcast 和估值过滤生成宏观驱动行业轮动研究材料。 | modeling | — | — | 待维护者审核 / 无公开端点 |  |
 
-### 监控与风险 Agent（3）
+### 监控与风险 Agent（7）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
+| [agent-alpha-portfolio-guardian](https://github.com/quantskills/agent-alpha-portfolio-guardian) | 多因子组合健康度守卫：健康度矩阵 + 拥挤警示 + 退休/重构候选 + IC 衰减曲线，含守卫规则有效性回测 L4。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
+| [agent-corporate-governance-scanner](https://github.com/quantskills/agent-corporate-governance-scanner) | 公司治理综合评分 Agent，9维度治理风险打分+证据链 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [agent-crowding-risk-monitor](https://github.com/quantskills/agent-crowding-risk-monitor) | 用 Pandadata 价格、成交、融资和龙虎榜热度识别抱团、过热、踩踏与去杠杆风险。 | monitoring | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/agent-crowding-risk-monitor.png"><img src="assets/agent-crowding-risk-monitor.png" width="260"></a> |
 | [agent-derivatives-skew-sentiment-monitor](https://github.com/quantskills/agent-derivatives-skew-sentiment-monitor) | 用期权隐含波动率和标的历史波动率观察衍生品市场风险偏好。 | monitoring | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/agent-derivatives-skew-sentiment-monitor.png"><img src="assets/agent-derivatives-skew-sentiment-monitor.png" width="260"></a> |
+| [agent-earnings-surprise-hunter](https://github.com/quantskills/agent-earnings-surprise-hunter) | 财报季 Surprise/暴雷猎手 Agent。获取财报预告、一致预期、审计意见，计算偏离度并生成分析报告。支持A股/港股/美股。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
+| [agent-intraday-rl-timing](https://github.com/quantskills/agent-intraday-rl-timing) | 纯研究的日内强化学习实验台：分钟数据建 Gym 环境 + 基线策略(TWAP/动量/反转) + 防泄漏 walk-forward 训练评估，绝不实盘下单。 | reporting | — | — | 待维护者审核 / 无公开端点 |  |
 | [agent-market-regime-monitor](https://github.com/quantskills/agent-market-regime-monitor) | 用 Pandadata 行情、指数宽度、波动率和资金证据判断趋势、震荡、退潮或风险扩张状态。 | monitoring | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/agent-market-regime-monitor.png"><img src="assets/agent-market-regime-monitor.png" width="260"></a> |
 
 ### 交易执行 Agent（1）
@@ -497,11 +554,12 @@ QuantSkills 是由 [PandaAI](https://www.pandaaiquant.com/) 发起的开放量�
 |---|---|---|---|---|---|---|
 | [agent-ssquant](https://github.com/quantskills/agent-ssquant) | SSQuant Agent 组织期货策略、数据服务、CTP 门禁检查和中文回测报告工作流。 | execution | — | — | 待维护者审核 / 无公开端点 |  |
 
-### 工作流编排 Agent（2）
+### 工作流编排 Agent（3）
 
 | 项目 | 双语摘要 | 主阶段 | 输入 | 输出 | 接口状态 | 截图 |
 |---|---|---|---|---|---|---|
 | [agent-for-liangshuyuan-tasks](https://github.com/quantskills/agent-for-liangshuyuan-tasks) | 面向量枢院任务的多 Agent 协作框架，组织量化交易工具、构建流程与任务分工。 | orchestration | — | — | 待维护者审核 / 无公开端点 |  |
+| [agent-future-trading](https://github.com/quantskills/agent-future-trading) | 多智能体期货研究、策略生成、历史回测与研究反馈工作流 | orchestration | — | — | 待维护者审核 / 无公开端点 |  |
 | [agent-quantspace](https://github.com/quantskills/agent-quantspace) | 面向 AI 编码代理的量化研究框架，组织数据、技能、策略、回测和报告工作流。 | orchestration | — | — | 待维护者审核 / 无公开端点 | <a href="https://raw.githubusercontent.com/quantskills/quantskills/main/assets/agent-quantspace.png"><img src="assets/agent-quantspace.png" width="260"></a> |
 
 </details>

--- a/scripts/catalog-model.mjs
+++ b/scripts/catalog-model.mjs
@@ -16,6 +16,6 @@ export function loadCatalogSnapshot(path) {
 
 export function buildCatalogModel(snapshot, presentation = {}) {
   const categories = CATEGORY_IDS.map((id) => ({ id, ...snapshot.taxonomy.categories[id] }));
-  const assets = [...snapshot.assets].sort((left, right) => left.name.localeCompare(right.name));
+  const assets = snapshot.assets.filter((asset) => asset.status !== "deprecated").sort((left, right) => left.name.localeCompare(right.name));
   return { snapshot_id: snapshot.snapshot_id, taxonomy: snapshot.taxonomy, categories, assets, resources: [...snapshot.resources], presentation };
 }

--- a/scripts/render-readme.mjs
+++ b/scripts/render-readme.mjs
@@ -97,7 +97,7 @@ export function replaceCatalog(template, model, language) {
   const catalog = renderCatalog(model, language);
   const marker = /<!-- CATALOG:START -->[\s\S]*?<!-- CATALOG:END -->/;
   if (!marker.test(template)) throw new Error("README template is missing catalog markers");
-  return template.replace(marker, `<!-- CATALOG:START -->\n${catalog}<!-- CATALOG:END -->`);
+  return template.replace(marker, `<!-- CATALOG:START -->\n${catalog}<!-- CATALOG:END -->`).replace(/\r\n/g, "\n");
 }
 
 export function renderReadme(model, language) {

--- a/scripts/verify-build.mjs
+++ b/scripts/verify-build.mjs
@@ -24,6 +24,9 @@ export function verifyBuild(outputDir, snapshot) {
     if (!actual || JSON.stringify(actual) !== JSON.stringify(asset)) throw new Error("output asset mismatch");
     if (!zh.includes(asset.name) || !en.includes(asset.name)) throw new Error("README asset mismatch");
   }
-  if (!zh.includes(`**${snapshot.assets.length}** 项公开资产`) || !en.includes(`**${snapshot.assets.length}** public assets`)) throw new Error("output count mismatch");
+  const count = snapshot.assets.length;
+  const zhCount = new RegExp(`<strong>${count}</strong>\\s*<br>\\s*<sub>资产</sub>`);
+  const enCount = new RegExp(`<strong>${count}</strong>\\s*<br>\\s*<sub>Assets</sub>`);
+  if (!zhCount.test(zh) || !enCount.test(en)) throw new Error("output count mismatch");
   return true;
 }

--- a/scripts/verify-build.mjs
+++ b/scripts/verify-build.mjs
@@ -18,13 +18,13 @@ export function verifyBuild(outputDir, snapshot) {
   const zhTemplate = readFileSync(join(ROOT, "docs", "README.zh.template.md"), "utf8");
   const enTemplate = readFileSync(join(ROOT, "docs", "README.en.template.md"), "utf8");
   if (zh !== replaceCatalog(zhTemplate, model, "zh") || en !== replaceCatalog(enTemplate, model, "en")) throw new Error("README projection mismatch");
-  if (names(site.assets) !== names(snapshot.assets) || names(site.resources) !== names(snapshot.resources) || JSON.stringify(site.taxonomy) !== JSON.stringify(snapshot.taxonomy) || JSON.stringify(site.profiles) !== JSON.stringify(snapshot.profiles.items) || JSON.stringify(site.adapters) !== JSON.stringify(snapshot.adapters.items) || JSON.stringify(site.compatibility_edges) !== JSON.stringify(snapshot.compatibility_edges)) throw new Error("output projection mismatch");
-  for (const asset of snapshot.assets) {
+  if (names(site.assets) !== names(model.assets) || names(site.resources) !== names(snapshot.resources) || JSON.stringify(site.taxonomy) !== JSON.stringify(snapshot.taxonomy) || JSON.stringify(site.profiles) !== JSON.stringify(snapshot.profiles.items) || JSON.stringify(site.adapters) !== JSON.stringify(snapshot.adapters.items) || JSON.stringify(site.compatibility_edges) !== JSON.stringify(snapshot.compatibility_edges)) throw new Error("output projection mismatch");
+  for (const asset of model.assets) {
     const actual = site.assets.find((item) => item.name === asset.name);
     if (!actual || JSON.stringify(actual) !== JSON.stringify(asset)) throw new Error("output asset mismatch");
     if (!zh.includes(asset.name) || !en.includes(asset.name)) throw new Error("README asset mismatch");
   }
-  const count = snapshot.assets.length;
+  const count = model.assets.length;
   const zhCount = new RegExp(`<strong>${count}</strong>\\s*<br>\\s*<sub>资产</sub>`);
   const enCount = new RegExp(`<strong>${count}</strong>\\s*<br>\\s*<sub>Assets</sub>`);
   if (!zhCount.test(zh) || !enCount.test(en)) throw new Error("output count mismatch");

--- a/site/catalog.json
+++ b/site/catalog.json
@@ -1,5 +1,5 @@
 {
-  "snapshot_id": "sha256:ecb9a3d03c6df06f3d5ca7961766ad2927ab3d370ee64e80343c0dd6946567a7",
+  "snapshot_id": "sha256:117387f24ed230521243f50541e0d1f8c10cd949848b4ba095c55222ba833c00",
   "taxonomy": {
     "categories": {
       "10": {
@@ -1547,45 +1547,6 @@
         "workflow_stages": [
           "data-ingestion",
           "monitoring",
-          "reporting"
-        ]
-      }
-    },
-    {
-      "catalog": {
-        "category": "05",
-        "subcategory": "05.performance-attribution"
-      },
-      "catalog_status": "approved",
-      "category": "05",
-      "commit_sha": "08b2be7386c49c640d974ef41dc4c5478288f201",
-      "declaration_file": "SKILL.md",
-      "declaration_status": "legacy",
-      "default_branch": "main",
-      "description": "Brinson-Fachler / BHB sector attribution with interaction, concentration (HHI), top contributors, and optional Carino multi-period linking. Use to explain active return as allocation vs selection.\n",
-      "health": "frozen-declaration-only",
-      "interface": null,
-      "interface_status": "pending-maintainer",
-      "last_validated": "2026-08-11",
-      "license": "GPL-3.0-only",
-      "maintainer_type": "community",
-      "name": "skill-brinson-performance-attribution",
-      "platforms": [],
-      "project_type": "skill",
-      "requires": [],
-      "stage": "evaluation",
-      "status": "active",
-      "subcategory": "05.performance-attribution",
-      "summary_en": "Runs Brinson-Fachler or BHB attribution with HHI, contributor ranking, and Carino multi-period linking.",
-      "summary_zh": "执行 Brinson-Fachler 或 BHB 归因、HHI 与贡献排序，并支持 Carino 多期链接。",
-      "tags": [],
-      "url": "https://github.com/quantskills/skill-brinson-performance-attribution",
-      "validation_level": "listed",
-      "workflow": {
-        "primary_stage": "evaluation",
-        "workflow_stages": [
-          "data-ingestion",
-          "evaluation",
           "reporting"
         ]
       }
@@ -5362,45 +5323,6 @@
           "factor-generation",
           "evaluation",
           "orchestration"
-        ]
-      }
-    },
-    {
-      "catalog": {
-        "category": "02",
-        "subcategory": "02.factor-generation"
-      },
-      "catalog_status": "approved",
-      "category": "02",
-      "commit_sha": "b169f31106f748b8746c4c1028c162e95f7277f4",
-      "declaration_file": "SKILL.md",
-      "declaration_status": "legacy",
-      "default_branch": "main",
-      "description": "Use when an agent needs a verified library of OHLCV volume, volume-price, ranking, and statistical alpha factor Skills for liquidity and distribution research.",
-      "health": "frozen-declaration-only",
-      "interface": null,
-      "interface_status": "pending-maintainer",
-      "last_validated": "2026-08-11",
-      "license": "GPL-3.0-only",
-      "maintainer_type": "community",
-      "name": "skill-quant-factor-volume-stat-alpha",
-      "platforms": [],
-      "project_type": "skill",
-      "requires": [],
-      "stage": "factor-generation",
-      "status": "active",
-      "subcategory": "02.factor-generation",
-      "summary_en": "Provides an OHLCV factor library for volume and price-volume statistical research.",
-      "summary_zh": "提供用于成交量和量价统计研究的 OHLCV 因子库。",
-      "tags": [],
-      "url": "https://github.com/quantskills/skill-quant-factor-volume-stat-alpha",
-      "validation_level": "listed",
-      "workflow": {
-        "primary_stage": "factor-generation",
-        "workflow_stages": [
-          "data-ingestion",
-          "factor-generation",
-          "evaluation"
         ]
       }
     },

--- a/site/catalog.json
+++ b/site/catalog.json
@@ -1,5 +1,5 @@
 {
-  "snapshot_id": "sha256:117387f24ed230521243f50541e0d1f8c10cd949848b4ba095c55222ba833c00",
+  "snapshot_id": "sha256:276e68899f6db4a7570a1b13cd84231f94987469343002522270686e52e87091",
   "taxonomy": {
     "categories": {
       "10": {
@@ -416,6 +416,105 @@
     {
       "catalog": {
         "category": "09",
+        "subcategory": "09.monitor-risk-agent"
+      },
+      "catalog_status": "approved",
+      "category": "09",
+      "commit_sha": "4c93fd6d93a5bca6e4cac178c2cf9d6ef7e8d241",
+      "declaration_file": "AGENTS.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Multi-factor portfolio health guardian. Orchestrates factor evaluate/decay, crowding risk, and smart-money profiling into a health matrix, crowding alerts, retire/rebuild candidates, and IC decay curves. Use when a research AI agent needs continuous portfolio-level factor monitoring without automated order placement.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "agent-alpha-portfolio-guardian",
+      "platforms": [
+        "claude-code",
+        "codex",
+        "hermes",
+        "openclaw",
+        "cursor"
+      ],
+      "project_type": "agent",
+      "requires": [
+        "skill-factor-evaluate",
+        "skill-factor-decay",
+        "agent-crowding-risk-monitor",
+        "skill-smart-money-profiler"
+      ],
+      "stage": "reporting",
+      "status": "draft",
+      "subcategory": "09.monitor-risk-agent",
+      "summary_en": "Multi-factor portfolio health guardian producing a health matrix, crowding alerts, retire/rebuild candidates, IC decay curves, and a research-only effectiveness backtest L4 page.",
+      "summary_zh": "多因子组合健康度守卫：健康度矩阵 + 拥挤警示 + 退休/重构候选 + IC 衰减曲线，含守卫规则有效性回测 L4。",
+      "tags": [
+        "quant",
+        "factor",
+        "portfolio",
+        "guardian",
+        "crowding",
+        "smart-money",
+        "pandadata"
+      ],
+      "url": "https://github.com/quantskills/agent-alpha-portfolio-guardian",
+      "validation_level": "runnable",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "monitoring",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "09",
+        "subcategory": "09.monitor-risk-agent"
+      },
+      "catalog_status": "approved",
+      "category": "09",
+      "commit_sha": "e326af2ead3d46f0adebbf5ff2a078a6ece89acd",
+      "declaration_file": "AGENTS.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "公司治理综合评分 Agent。对 A 股上市公司进行 9 维度治理风险打分（0-100）并生成逐项证据链：审计意见、诉讼风险、关联交易、担保风险、合同风险、中介机构、股权性质、违规记录、举牌收购。LLM 编排 + PandaData 数据驱动。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "agent-corporate-governance-scanner",
+      "platforms": [],
+      "project_type": "agent",
+      "requires": [],
+      "stage": "reporting",
+      "status": "stable",
+      "subcategory": "09.monitor-risk-agent",
+      "summary_en": "Corporate governance scoring agent with 9-dimension risk scoring and evidence chains",
+      "summary_zh": "公司治理综合评分 Agent，9维度治理风险打分+证据链",
+      "tags": [],
+      "url": "https://github.com/quantskills/agent-corporate-governance-scanner",
+      "validation_level": "verified",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "monitoring",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "09",
         "subcategory": "09.research-agent"
       },
       "catalog_status": "approved",
@@ -534,6 +633,96 @@
     {
       "catalog": {
         "category": "09",
+        "subcategory": "09.monitor-risk-agent"
+      },
+      "catalog_status": "approved",
+      "category": "09",
+      "commit_sha": "2173d3a851ddf0d221fc0f5d3750e5962ab40c4a",
+      "declaration_file": "AGENTS.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "财报季 Surprise/暴雷猎手 Agent。获取财报预告、一致预期、审计意见，计算偏离度并生成分析报告。支持A股/港股/美股。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "agent-earnings-surprise-hunter",
+      "platforms": [],
+      "project_type": "agent",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "09.monitor-risk-agent",
+      "summary_en": "财报季 Surprise/暴雷猎手 Agent。获取财报预告、一致预期、审计意见，计算偏离度并生成分析报告。支持A股/港股/美股。",
+      "summary_zh": "财报季 Surprise/暴雷猎手 Agent。获取财报预告、一致预期、审计意见，计算偏离度并生成分析报告。支持A股/港股/美股。",
+      "tags": [],
+      "url": "https://github.com/quantskills/agent-earnings-surprise-hunter",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "monitoring",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "09",
+        "subcategory": "09.research-agent"
+      },
+      "catalog_status": "approved",
+      "category": "09",
+      "commit_sha": "7f100672d95eff4c2351517ba2c6a1be7ddea464",
+      "declaration_file": "AGENTS.md",
+      "declaration_status": "legacy",
+      "default_branch": "master",
+      "description": "追踪微博\"峰哥亡命天涯\"的发言，提取其股票/市场观点，生成反向操作信号，并通过Pandadata实现K线图信号标注、回测验证和虚拟交易系统。峰哥是A股知名反向指标——其公开观点具有稳定反向参考价值。Use when the user asks for 峰哥反向指标, 峰哥亡命天涯, 反向指标, 峰哥观点, 峰哥持仓, or to check what Feng Ge is saying about the market.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "agent-feng-reverse",
+      "platforms": [],
+      "project_type": "agent",
+      "requires": [],
+      "stage": "reporting",
+      "status": "draft",
+      "subcategory": "09.research-agent",
+      "summary_en": "Tracks Weibo user \"峰哥亡命天涯\" (Feng Ge), a well-known A-share reverse indicator. Extracts stock/market opinions from his posts and generates contrarian trading signals.",
+      "summary_zh": "追踪微博\"峰哥亡命天涯\"的发言，提取股票/市场观点，生成反向操作信号。峰哥是A股知名反向指标，其公开观点具有稳定的反向参考价值。",
+      "tags": [
+        "a-share",
+        "weibo",
+        "reverse-indicator",
+        "sentiment",
+        "feng-ge",
+        "contrarian",
+        "backtest",
+        "chart",
+        "database"
+      ],
+      "url": "https://github.com/quantskills/agent-feng-reverse",
+      "validation_level": "runnable",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "monitoring",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "09",
         "subcategory": "09.workflow-orchestration-agent"
       },
       "catalog_status": "approved",
@@ -565,6 +754,113 @@
         "primary_stage": "orchestration",
         "workflow_stages": [
           "orchestration"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "09",
+        "subcategory": "09.workflow-orchestration-agent"
+      },
+      "catalog_status": "approved",
+      "category": "09",
+      "commit_sha": "42a899733db3173a331159fb25d29d78eb4d3e32",
+      "declaration_file": "AGENTS.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "基于 LangGraph 编排的多智能体期货研究与回测工作流，适用于结构化市场分析、组合决策、历史复刻、执行检查、结算和研究反馈。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "agent-future-trading",
+      "platforms": [
+        "cursor",
+        "claude-code",
+        "codex",
+        "hermes",
+        "openclaw"
+      ],
+      "project_type": "agent",
+      "requires": [],
+      "stage": "orchestration",
+      "status": "draft",
+      "subcategory": "09.workflow-orchestration-agent",
+      "summary_en": "Multi-agent futures research, strategy generation, backtesting, and research feedback workflow",
+      "summary_zh": "多智能体期货研究、策略生成、历史回测与研究反馈工作流",
+      "tags": [
+        "futures",
+        "multi-agent",
+        "langgraph",
+        "langchain",
+        "backtesting",
+        "portfolio-construction",
+        "research-loop"
+      ],
+      "url": "https://github.com/quantskills/agent-future-trading",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "orchestration",
+        "workflow_stages": [
+          "data-ingestion",
+          "data-quality",
+          "modeling",
+          "portfolio-construction",
+          "backtesting",
+          "evaluation",
+          "risk",
+          "execution",
+          "reporting",
+          "orchestration"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "09",
+        "subcategory": "09.monitor-risk-agent"
+      },
+      "catalog_status": "approved",
+      "category": "09",
+      "commit_sha": "beeb3718bd081926d62e9f48cea3fe5967ce7be1",
+      "declaration_file": "AGENTS.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "A research-only reinforcement-learning lab for intraday timing on minute bars. Builds a Gymnasium-style trading environment from Pandadata minute data, ships baseline policies (TWAP, intraday momentum, intraday reversal), and a leakage-aware walk-forward train/eval harness for offline/online RL (DQN-style). Use when a research agent needs to prototype and benchmark intraday-timing policies against baselines with realistic fees/slippage — never for live order placement.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "agent-intraday-rl-timing",
+      "platforms": [],
+      "project_type": "agent",
+      "requires": [],
+      "stage": "reporting",
+      "status": "draft",
+      "subcategory": "09.monitor-risk-agent",
+      "summary_en": "Research-only RL lab for intraday timing on minute bars: Gym env, baseline policies, leakage-aware walk-forward train/eval. No live orders.",
+      "summary_zh": "纯研究的日内强化学习实验台：分钟数据建 Gym 环境 + 基线策略(TWAP/动量/反转) + 防泄漏 walk-forward 训练评估，绝不实盘下单。",
+      "tags": [
+        "reinforcement-learning",
+        "intraday",
+        "minute-bars",
+        "gymnasium",
+        "walk-forward",
+        "research-only"
+      ],
+      "url": "https://github.com/quantskills/agent-intraday-rl-timing",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "monitoring",
+          "reporting"
         ]
       }
     },
@@ -767,6 +1063,45 @@
     },
     {
       "catalog": {
+        "category": "03",
+        "subcategory": "03.a-share-equity"
+      },
+      "catalog_status": "approved",
+      "category": "03",
+      "commit_sha": "e0984965ff8bd26fec67a798a9f35c5717d0a301",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Analyze A-share cross-sectional market participation, turnover concentration, liquidity distribution, speculative crowding, leader dependence, and structural fragility from daily or intraday stock snapshots. Use when the user asks in Chinese or English to analyze A-share market breadth, participation, turnover concentration, crowding, whether an index rally is broad or narrow, or to generate a reproducible market-structure report. Use only bundled scripts with PandaData as the primary live source, AKShare as fallback, or user-provided local data; never search, browse, or scrape webpages for replacement market data, and fail closed when approved sources are unavailable. Do not use for order routing, fill simulation, slippage/TCA, live trade execution, or stock-level margin/northbound/block-trade capital-flow attribution.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-a-share-market-participation",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "03.a-share-equity",
+      "summary_en": "Analyze A-share cross-sectional market participation, turnover concentration, liquidity distribution, speculative crowding, leader dependence, and structural fragility from daily or intraday stock snapshots. Use when the user asks in Chinese or English to analyze A-share market breadth, participation, turnover concentration, crowding, whether an index rally is broad or narrow, or to generate a reproducible market-structure report. Use only bundled scripts with PandaData as the primary live source, AKShare as fallback, or user-provided local data; never search, browse, or scrape webpages for replacement market data, and fail closed when approved sources are unavailable. Do not use for order routing, fill simulation, slippage/TCA, live trade execution, or stock-level margin/northbound/block-trade capital-flow attribution.",
+      "summary_zh": "Analyze A-share cross-sectional market participation, turnover concentration, liquidity distribution, speculative crowding, leader dependence, and structural fragility from daily or intraday stock snapshots. Use when the user asks in Chinese or English to analyze A-share market breadth, participation, turnover concentration, crowding, whether an index rally is broad or narrow, or to generate a reproducible market-structure report. Use only bundled scripts with PandaData as the primary live source, AKShare as fallback, or user-provided local data; never search, browse, or scrape webpages for replacement market data, and fail closed when approved sources are unavailable. Do not use for order routing, fill simulation, slippage/TCA, live trade execution, or stock-level margin/northbound/block-trade capital-flow attribution.",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-a-share-market-participation",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
         "category": "04",
         "subcategory": "04.automated-alerts"
       },
@@ -883,6 +1218,62 @@
     },
     {
       "catalog": {
+        "category": "03",
+        "subcategory": "03.a-share-equity"
+      },
+      "catalog_status": "approved",
+      "category": "03",
+      "commit_sha": "0d1cbdafde3ddb148a0bed90d06ad09525bfecee",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "A-share tradability-constraint auditor — replays a backtest or signal trade log against date-resolved price limits (10%/20%/30%; main-board ST was 5% until the 2026-07-06 rule change), locked vs intraday-opened limit bars, suspensions, T+1 settlement, the naked-short ban, the new-listing window and turnover participation caps, then splits headline PnL into executable PnL and phantom PnL. Use when the user asks 回测收益是不是真的能成交、涨停买不进、 跌停卖不出、停牌怎么处理、T+1 约束、一字板、可交易性/可成交性审计, or wants to know why a live account underperforms its backtest. Fills the ecosystem gap: the four existing auditors all check whether the DATA is right, none checks whether the EXECUTION ASSUMPTION is possible.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-a-share-tradability-auditor",
+      "platforms": [
+        "claude-code",
+        "codex",
+        "hermes",
+        "openclaw",
+        "cursor"
+      ],
+      "project_type": "skill",
+      "requires": [
+        "skill-pandadata-api"
+      ],
+      "stage": "reporting",
+      "status": "draft",
+      "subcategory": "03.a-share-equity",
+      "summary_en": "A-share tradability-constraint auditor — replays a backtest or signal trade log against date-resolved price limits (10%/20%/30%; main-board ST was 5% until the 2026-07-06 rule change), locked vs intraday-opened limit bars, suspensions, T+1 settlement, the naked-short ban, the new-listing window and turnover participation caps, then splits headline PnL into executable PnL and phantom PnL. Use when the user asks 回测收益是不是真的能成交、涨停买不进、 跌停卖不出、停牌怎么处理、T+1 约束、一字板、可交易性/可成交性审计, or wants to know why a live account underperforms its backtest. Fills the ecosystem gap: the four existing auditors all check whether the DATA is right, none checks whether the EXECUTION ASSUMPTION is possible.",
+      "summary_zh": "A 股可交易性约束审计：把回测交易流放回历史行情，逐笔判定涨跌停封板、停牌、T+1、 裸卖空、新股窗口与参与率上限，把账面收益拆成\"可成交收益\"与\"幽灵收益\"， 并定位到具体交易。回答\"这条净值曲线里有多少是市场根本不会给你的\"。",
+      "tags": [
+        "a-share",
+        "tradability",
+        "price-limit",
+        "t-plus-1",
+        "suspension",
+        "backtest-integrity",
+        "execution",
+        "pandadata"
+      ],
+      "url": "https://github.com/quantskills/skill-a-share-tradability-auditor",
+      "validation_level": "runnable",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
         "category": "02",
         "subcategory": "02.factor-generation"
       },
@@ -961,6 +1352,59 @@
     },
     {
       "catalog": {
+        "category": "06",
+        "subcategory": "06.investor-research-models"
+      },
+      "catalog_status": "approved",
+      "category": "06",
+      "commit_sha": "33b26ef77ae97c5a824b1441d124023308cf78bb",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Monitor and research relative valuation between dual-listed A-share and H-share securities using bundled scripts, PandaData, and HKMA FX data. Use when analyzing A/H premiums or discounts, FX-adjusted price gaps, historical premium percentiles and z-scores, cross-market dislocations, daily lead-lag proxies, market-wide A/H scans, single-company A/H questions, or company-name-to-code lookup for mainland China and Hong Kong listings. Prefer the skill's scripts and normalized CSVs; never browse unrelated webpages or manually scrape public sites for this skill. If PandaData or live data access fails, fail closed instead of searching the web. Produce reproducible JSON and Markdown research outputs; do not present price gaps as guaranteed arbitrage or place trades.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-ah-share-relative-value-montior",
+      "platforms": [
+        "codex",
+        "claude-code",
+        "cursor",
+        "hermes",
+        "openclaw"
+      ],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "06.investor-research-models",
+      "summary_en": "Monitor FX-adjusted A/H premiums, historical extremes, dislocations, and daily cross-market price-discovery proxies.",
+      "summary_zh": "监控A/H双重上市股票的汇率调整溢价、历史极值、脱钩与日频价格发现关系。",
+      "tags": [
+        "a-share",
+        "h-share",
+        "ah-premium",
+        "relative-value",
+        "cross-market",
+        "fx",
+        "lead-lag"
+      ],
+      "url": "https://github.com/quantskills/skill-ah-share-relative-value-montior",
+      "validation_level": "runnable",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
         "category": "02",
         "subcategory": "02.factor-generation"
       },
@@ -991,6 +1435,46 @@
       "validation_level": "listed",
       "workflow": {
         "primary_stage": "factor-generation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "factor-generation",
+          "evaluation"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "02",
+        "subcategory": "02.factor-generation"
+      },
+      "catalog_status": "approved",
+      "category": "02",
+      "commit_sha": "c1de583f6f42c559020b2d3d2b6fdab654ed8c82",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "连板龙头接力（A3）Alpha 因子——从全 A 市场每日 ≥3 板候选池中识别 T+1 接力的事件型 top-N 信号，10 个子因子（个股截面 8 + 大盘情绪 2），权重可用 ICIR + shrinkage 重训，含滚动 IC gate 与 score 加权。研究层面的候选发现器，非交易策略。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-alpha-a3-streak-leader-relay",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "evaluation",
+      "status": "active",
+      "subcategory": "02.factor-generation",
+      "summary_en": "连板龙头接力（A3）Alpha 因子——从全 A 市场每日 ≥3 板候选池中识别 T+1 接力的事件型 top-N 信号，10 个子因子（个股截面 8 + 大盘情绪 2），权重可用 ICIR + shrinkage 重训，含滚动 IC gate 与 score 加权。研究层面的候选发现器，非交易策略。",
+      "summary_zh": "连板龙头接力（A3）Alpha 因子——从全 A 市场每日 ≥3 板候选池中识别 T+1 接力的事件型 top-N 信号，10 个子因子（个股截面 8 + 大盘情绪 2），权重可用 ICIR + shrinkage 重训，含滚动 IC gate 与 score 加权。研究层面的候选发现器，非交易策略。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-alpha-a3-streak-leader-relay",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
         "workflow_stages": [
           "data-ingestion",
           "feature-engineering",
@@ -1148,46 +1632,6 @@
       "summary_zh": "从期货家族席位与主力席位持仓背离计算因子信号。",
       "tags": [],
       "url": "https://github.com/quantskills/skill-alpha-f8-family-main-divergence",
-      "validation_level": "listed",
-      "workflow": {
-        "primary_stage": "factor-generation",
-        "workflow_stages": [
-          "data-ingestion",
-          "feature-engineering",
-          "factor-generation",
-          "evaluation"
-        ]
-      }
-    },
-    {
-      "catalog": {
-        "category": "02",
-        "subcategory": "02.factor-generation"
-      },
-      "catalog_status": "approved",
-      "category": "02",
-      "commit_sha": "066eb0f86eb03f40a4ee639bdb651d928d89f262",
-      "declaration_file": "SKILL.md",
-      "declaration_status": "legacy",
-      "default_branch": "main",
-      "description": "当需要开发、计算、验证 Graham 净净营运资本(NCAV) 因子时，使用此 skill。适用于 A 股全市场深度价值筛选，排除银行/房地产/非银金融，计算 NCAV 折价因子并生成 buy/sell/hold 信号。",
-      "health": "frozen-declaration-only",
-      "interface": null,
-      "interface_status": "pending-maintainer",
-      "last_validated": "2026-08-11",
-      "license": "GPL-3.0-only",
-      "maintainer_type": "community",
-      "name": "skill-alpha-ncav-graham",
-      "platforms": [],
-      "project_type": "skill",
-      "requires": [],
-      "stage": "factor-generation",
-      "status": "active",
-      "subcategory": "02.factor-generation",
-      "summary_en": "Computes a Graham NCAV discount factor for A-share deep-value screening and buy-sell-hold signals.",
-      "summary_zh": "计算 Graham NCAV 净流动资产折价因子，面向排除金融股的 A 股深度价值筛选并生成信号。",
-      "tags": [],
-      "url": "https://github.com/quantskills/skill-alpha-ncav-graham",
       "validation_level": "listed",
       "workflow": {
         "primary_stage": "factor-generation",
@@ -1437,6 +1881,52 @@
     {
       "catalog": {
         "category": "07",
+        "subcategory": "07.workflow-audit"
+      },
+      "catalog_status": "approved",
+      "category": "07",
+      "commit_sha": "0332e475abcb399b5949999cf1d0ffc9559aa00f",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Use when an agent needs to independently audit the assumptions and biases behind a backtest / strategy code / research backtest report — execution timing and lookahead, trading costs, price limits and suspensions, survivorship bias, parameter freedom and multiple testing, data alignment and adjustment, turnover and capacity, benchmark and excess returns, and reporting transparency. Outputs a structured defect list (axis x evidence x severity x impact x fix).",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-backtest-assumption_check",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "stable",
+      "subcategory": "07.workflow-audit",
+      "summary_en": "Use when an agent needs to independently audit the assumptions and biases behind a backtest / strategy code / research backtest report — execution timing and lookahead, trading costs, price limits and suspensions, survivorship bias, parameter freedom and multiple testing, data alignment and adjustment, turnover and capacity, benchmark and excess returns, and reporting transparency. Outputs a structured defect list (axis x evidence x severity x impact x fix).",
+      "summary_zh": "独立的回测假设审计师：对回测代码/策略代码/研究报告按九大维度（成交时点、成本、涨跌停停牌、幸存者、多重比较、数据对齐、换手容量、基准、透明）逐条取证，输出缺陷×证据×严重度×影响×修复清单，配套可运行校验脚本。",
+      "tags": [
+        "backtest-audit",
+        "lookahead",
+        "survivorship",
+        "multiple-testing",
+        "trading-costs"
+      ],
+      "url": "https://github.com/quantskills/skill-backtest-assumption_check",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "data-quality",
+          "evaluation",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "07",
         "subcategory": "07.walk-forward-oos"
       },
       "catalog_status": "approved",
@@ -1587,6 +2077,51 @@
           "data-ingestion",
           "modeling",
           "evaluation",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "03",
+        "subcategory": "03.a-share-equity"
+      },
+      "catalog_status": "approved",
+      "category": "03",
+      "commit_sha": "08b4e44a01d493e70cbd478b95a45e57fb7997d7",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "PandaData-only, point-in-time A-share Buffett moat hard screener with ten-year return consistency, margin stability, capital intensity, debt and TTM valuation evidence. Use when an agent needs an auditable quality screen, historical signal reconstruction, or annual factor validation without future information.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-buffett-moat-screener--lavineversion",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "03.a-share-equity",
+      "summary_en": "PandaData-only point-in-time Buffett moat hard screener for A-shares.",
+      "summary_zh": "基于 PandaData 点时证据执行十年资本回报与护城河硬筛选。",
+      "tags": [
+        "a-share",
+        "buffett",
+        "fundamental",
+        "point-in-time",
+        "screener"
+      ],
+      "url": "https://github.com/quantskills/skill-buffett-moat-screener--lavineversion",
+      "validation_level": "runnable",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
           "reporting"
         ]
       }
@@ -1745,6 +2280,57 @@
           "data-ingestion",
           "monitoring",
           "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "02",
+        "subcategory": "02.factor-generation"
+      },
+      "catalog_status": "approved",
+      "category": "02",
+      "commit_sha": "c4d186a9bbedd05890472fd3e2c006cdcfa5d6a9",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Discover causal alpha factors from OHLCV data using causal discovery (PC + LiNGAM + NOTEARS), build Structural Causal Models, construct regime-invariant factor expressions, and validate through backtesting. Produces OHLCV-only alpha factors whose predictive power is grounded in causal mechanisms rather than spurious correlations. Use when an agent needs to discover stable alpha factors that survive regime changes, test whether existing factors are causal or merely correlational, or generate alpha factors with formal invariance guarantees on portable agent platforms such as Claude Code, Codex, or Codex-style skill systems.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-causal-alpha-discovery",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "evaluation",
+      "status": "draft",
+      "subcategory": "02.factor-generation",
+      "summary_en": "Discover causal alpha factors from OHLCV data using causal discovery (PC + LiNGAM + NOTEARS), build Structural Causal Models, construct regime-invariant factor expressions, and validate through backtesting. Produces OHLCV-only alpha factors whose predictive power is grounded in causal mechanisms rather than spurious correlations. Use when an agent needs to discover stable alpha factors that survive regime changes, test whether existing factors are causal or merely correlational, or generate alpha factors with formal invariance guarantees on portable agent platforms such as Claude Code, Codex, or Codex-style skill systems.",
+      "summary_zh": "Discover causal alpha factors from OHLCV data using causal discovery (PC + LiNGAM + NOTEARS), build Structural Causal Models, construct regime-invariant factor expressions, and validate through backtesting. Produces OHLCV-only alpha factors whose predictive power is grounded in causal mechanisms rather than spurious correlations. Use when an agent needs to discover stable alpha factors that survive regime changes, test whether existing factors are causal or merely correlational, or generate alpha factors with formal invariance guarantees on portable agent platforms such as Claude Code, Codex, or Codex-style skill systems.",
+      "tags": [
+        "causal-discovery",
+        "causal-inference",
+        "alpha-generation",
+        "factor-discovery",
+        "regime-invariance",
+        "structural-causal-model",
+        "do-calculus",
+        "ohlcv",
+        "stock-selection",
+        "cross-sectional"
+      ],
+      "url": "https://github.com/quantskills/skill-causal-alpha-discovery",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "factor-generation",
+          "evaluation"
         ]
       }
     },
@@ -1950,6 +2536,54 @@
     },
     {
       "catalog": {
+        "category": "04",
+        "subcategory": "04.regulatory-compliance"
+      },
+      "catalog_status": "approved",
+      "category": "04",
+      "commit_sha": "f2c6e548d5e4d1a44cd073ab04aca09a3a91dfc2",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "A-share CSRC approval pipeline tracking skill — monitors regulatory approval progress, categorizes by announcement level, and generates pipeline status reports. Use when the user asks to track CSRC approval progress, monitor regulatory announcements, check approval pipeline status, or generate approval progress reports.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-csrc-approval-pipeline",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [
+        "skill-pandadata-api"
+      ],
+      "stage": "reporting",
+      "status": "draft",
+      "subcategory": "04.regulatory-compliance",
+      "summary_en": "A-share CSRC approval pipeline tracking: categorization by announcement level, approval flow monitoring, and status report generation.",
+      "summary_zh": "A 股证监会批文进度追踪：按公告级别分类、审批流程监控、批文状态报告生成。",
+      "tags": [
+        "a-share",
+        "csrc",
+        "approval",
+        "pipeline",
+        "pandadata"
+      ],
+      "url": "https://github.com/quantskills/skill-csrc-approval-pipeline",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "risk",
+          "monitoring",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
         "category": "08",
         "subcategory": "08.daily-review"
       },
@@ -2028,6 +2662,114 @@
     },
     {
       "catalog": {
+        "category": "04",
+        "subcategory": "04.portfolio-stress"
+      },
+      "catalog_status": "approved",
+      "category": "04",
+      "commit_sha": "554ffc48fc46f3ffc9039406ec40938a20424351",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Price options and other derivatives and quantify their risk from a contract specification and market inputs, covering Black-Scholes-Merton analytical pricing, the full set of Greeks, binomial-tree and Monte-Carlo numerical pricing with convergence checks, implied-volatility inversion, volatility smile/skew structure, and model-risk validation (put-call parity, no-arbitrage bounds, cross-method consistency). Use when the user asks for 期权定价、希腊字母计算、隐含波动率、波动率微笑/曲面、二叉树或蒙特卡洛定价、Black-Scholes、美式期权定价、看跌看涨平价校验, or a one-stop option pricing and risk dossier.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-derivatives-pricing-stochastic-calculus",
+      "platforms": [
+        "claude-code",
+        "codex",
+        "openclaw",
+        "cursor",
+        "hermes"
+      ],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "stable",
+      "subcategory": "04.portfolio-stress",
+      "summary_en": "Price options and other derivatives and quantify their risk from a contract specification and market inputs, covering Black-Scholes-Merton analytical pricing, the full set of Greeks, binomial-tree and Monte-Carlo numerical pricing with convergence checks, implied-volatility inversion, volatility smile/skew structure, and model-risk validation (put-call parity, no-arbitrage bounds, cross-method consistency). Use when the user asks for 期权定价、希腊字母计算、隐含波动率、波动率微笑/曲面、二叉树或蒙特卡洛定价、Black-Scholes、美式期权定价、看跌看涨平价校验, or a one-stop option pricing and risk dossier.",
+      "summary_zh": "输入期权合约与市场参数，输出可复现的定价与风险报告：BSM 解析价、全套希腊字母、二叉树与蒙特卡洛数值价、隐含波动率、平价与无套利校验，一次算清。",
+      "tags": [
+        "derivatives-pricing",
+        "options",
+        "black-scholes",
+        "greeks",
+        "implied-volatility",
+        "monte-carlo",
+        "binomial-tree",
+        "stochastic-calculus"
+      ],
+      "url": "https://github.com/quantskills/skill-derivatives-pricing-stochastic-calculus",
+      "validation_level": "runnable",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "risk",
+          "monitoring",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "08",
+        "subcategory": "08.news-disclosures"
+      },
+      "catalog_status": "approved",
+      "category": "08",
+      "commit_sha": "6fae7ed42fde63fd7fd12807a4c866e95eaeb709",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Turn unstructured A-share disclosure text from cninfo (巨潮) and the SSE/SZSE exchanges into a traceable, structured event table (监管问询/诉讼担保/重组/治理/ 停牌控制权变更/增减持/质押/业绩预告). Use when the user asks to scan A-share announcements, find 关注函/问询函/诉讼/停牌/易主 events, build an event table for factor or alert pipelines, or backtest disclosure events. Fills the information-search gap Pandadata does not cover.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-disclosure-event-extractor",
+      "platforms": [
+        "claude-code",
+        "codex",
+        "hermes",
+        "openclaw",
+        "cursor"
+      ],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "stable",
+      "subcategory": "08.news-disclosures",
+      "summary_en": "Turn unstructured A-share disclosure text from cninfo (巨潮) and the SSE/SZSE exchanges into a traceable, structured event table (监管问询/诉讼担保/重组/治理/ 停牌控制权变更/增减持/质押/业绩预告). Use when the user asks to scan A-share announcements, find 关注函/问询函/诉讼/停牌/易主 events, build an event table for factor or alert pipelines, or backtest disclosure events. Fills the information-search gap Pandadata does not cover.",
+      "summary_zh": "Turn unstructured A-share disclosure text from cninfo (巨潮) and the SSE/SZSE exchanges into a traceable, structured event table (监管问询/诉讼担保/重组/治理/ 停牌控制权变更/增减持/质押/业绩预告). Use when the user asks to scan A-share announcements, find 关注函/问询函/诉讼/停牌/易主 events, build an event table for factor or alert pipelines, or backtest disclosure events. Fills the information-search gap Pandadata does not cover.",
+      "tags": [
+        "a-share",
+        "disclosure",
+        "announcement",
+        "event-extraction",
+        "cninfo",
+        "web-scraping",
+        "event-driven"
+      ],
+      "url": "https://github.com/quantskills/skill-disclosure-event-extractor",
+      "validation_level": "runnable",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "evaluation",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
         "category": "03",
         "subcategory": "03.a-share-equity"
       },
@@ -2071,6 +2813,46 @@
       },
       "catalog_status": "approved",
       "category": "06",
+      "commit_sha": "e9df0dc55a6184ed4a637c7a970d528dcc861405",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "深度自编码器无监督异常检测 —— 用户问「今天哪些股票走势最异常」「沪深300 异常股」「AE 跑一下」「找不像自己往常样子的股票」类问题时触发。对沪深300成分股用最近60日窗口重训一个MLP自编码器，输出T日重建误差Top-10异常股，按「样式② 结构化播报」呈现。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-dl-autoencoder-anomaly",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "evaluation",
+      "status": "active",
+      "subcategory": "06.statistical-ml-models",
+      "summary_en": "深度自编码器无监督异常检测 —— 用户问「今天哪些股票走势最异常」「沪深300 异常股」「AE 跑一下」「找不像自己往常样子的股票」类问题时触发。对沪深300成分股用最近60日窗口重训一个MLP自编码器，输出T日重建误差Top-10异常股，按「样式② 结构化播报」呈现。",
+      "summary_zh": "深度自编码器无监督异常检测 —— 用户问「今天哪些股票走势最异常」「沪深300 异常股」「AE 跑一下」「找不像自己往常样子的股票」类问题时触发。对沪深300成分股用最近60日窗口重训一个MLP自编码器，输出T日重建误差Top-10异常股，按「样式② 结构化播报」呈现。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-dl-autoencoder-anomaly",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "modeling",
+          "evaluation"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "06",
+        "subcategory": "06.statistical-ml-models"
+      },
+      "catalog_status": "approved",
+      "category": "06",
       "commit_sha": "2ecd99ae31d2d2bc3d57149818781615fbfbfb41",
       "declaration_file": "SKILL.md",
       "declaration_status": "legacy",
@@ -2100,6 +2882,86 @@
           "feature-engineering",
           "modeling",
           "backtesting",
+          "evaluation"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "06",
+        "subcategory": "06.statistical-ml-models"
+      },
+      "catalog_status": "approved",
+      "category": "06",
+      "commit_sha": "1733a8a9f7653ef0063b56a2221c7f82df759e1c",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "使用因果扩张 Temporal Convolutional Network 对沪深 A 股分钟线执行未来 1、2、3、5 个交易日的横截面收益排序研究，并以同数据、切分和预算的 LSTM 作为基准，生成可审计的数据、训练、速度和预测效果证据。用于运行或诊断 TCN 短线预测、核验感受野与因果卷积、PIT/walk-forward/purge/embargo、防止未来泄漏、比较 RankIC/Top 区域指标与训练吞吐，或判断研究模型是否达到冻结候选条件；不用于组合换手优化、券商连接、实盘交易或收益承诺。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-dl-tcn-shortterm",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "evaluation",
+      "status": "active",
+      "subcategory": "06.statistical-ml-models",
+      "summary_en": "使用因果扩张 Temporal Convolutional Network 对沪深 A 股分钟线执行未来 1、2、3、5 个交易日的横截面收益排序研究，并以同数据、切分和预算的 LSTM 作为基准，生成可审计的数据、训练、速度和预测效果证据。用于运行或诊断 TCN 短线预测、核验感受野与因果卷积、PIT/walk-forward/purge/embargo、防止未来泄漏、比较 RankIC/Top 区域指标与训练吞吐，或判断研究模型是否达到冻结候选条件；不用于组合换手优化、券商连接、实盘交易或收益承诺。",
+      "summary_zh": "使用因果扩张 Temporal Convolutional Network 对沪深 A 股分钟线执行未来 1、2、3、5 个交易日的横截面收益排序研究，并以同数据、切分和预算的 LSTM 作为基准，生成可审计的数据、训练、速度和预测效果证据。用于运行或诊断 TCN 短线预测、核验感受野与因果卷积、PIT/walk-forward/purge/embargo、防止未来泄漏、比较 RankIC/Top 区域指标与训练吞吐，或判断研究模型是否达到冻结候选条件；不用于组合换手优化、券商连接、实盘交易或收益承诺。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-dl-tcn-shortterm",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "modeling",
+          "evaluation"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "06",
+        "subcategory": "06.statistical-ml-models"
+      },
+      "catalog_status": "approved",
+      "category": "06",
+      "commit_sha": "7c2e647a9af04c760db7a35efadb751eee7f917d",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-dl-transformer-multiasset",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "evaluation",
+      "status": "active",
+      "subcategory": "06.statistical-ml-models",
+      "summary_en": "skill dl transformer multiasset",
+      "summary_zh": "skill dl transformer multiasset",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-dl-transformer-multiasset",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "modeling",
           "evaluation"
         ]
       }
@@ -2149,6 +3011,57 @@
       },
       "catalog_status": "approved",
       "category": "08",
+      "commit_sha": "d615f1c2c098d646d7b5d9a4832d9a07adc3fd93",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Formal CAR event-study for A-share / equity earnings (or any corporate) events: abnormal returns, cumulative abnormal returns, cross-sectional t-tests and sign tests across event windows. Use when the user asks 财报事件研究, CAR, 异常收益, 事件窗口, earnings surprise reaction, average abnormal return around earnings, or event-study statistics — not for real-time event-risk monitoring/alerts.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-earnings-event-study",
+      "platforms": [
+        "claude-code",
+        "codex",
+        "cursor",
+        "hermes",
+        "openclaw"
+      ],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "stable",
+      "subcategory": "08.news-disclosures",
+      "summary_en": "Formal CAR event study around earnings/corporate events — abnormal returns, multi-window CARs, t-tests and sign tests, with sample and model disclosure; research only, no trading advice.",
+      "summary_zh": "对财报/公司事件做正式 CAR 事件研究：异常收益、多窗口累计异常收益、截面 t 检验与符号检验；披露样本量与模型，不输出买卖建议。",
+      "tags": [
+        "event-study",
+        "car",
+        "earnings",
+        "abnormal-return",
+        "a-share"
+      ],
+      "url": "https://github.com/quantskills/skill-earnings-event-study",
+      "validation_level": "runnable",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "evaluation",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "08",
+        "subcategory": "08.news-disclosures"
+      },
+      "catalog_status": "approved",
+      "category": "08",
       "commit_sha": "203f4f69b029468f50d1b9aa08f71814d472a945",
       "declaration_file": "SKILL.md",
       "declaration_status": "legacy",
@@ -2177,6 +3090,45 @@
         "workflow_stages": [
           "data-ingestion",
           "monitoring",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "03",
+        "subcategory": "03.a-share-equity"
+      },
+      "catalog_status": "approved",
+      "category": "03",
+      "commit_sha": "499db18924760203e88285a56fde6214be7177d5",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "举牌行为监控——侦测 A 股股东持股比例上穿 5%/10%/15%/20%/25%/30% 法定披露梯度的权益变动事件，含举牌梯度、意图倾向（财务 vs 战略）、6 个月锁定期、逼近举牌线观察名单。剔除通道账户与股本稀释造成的假举牌。BUILD 型 skill，可被复盘 agent 或事件驱动 Alpha 调用。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-equity-placard-watchlist",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "03.a-share-equity",
+      "summary_en": "举牌行为监控——侦测 A 股股东持股比例上穿 5%/10%/15%/20%/25%/30% 法定披露梯度的权益变动事件，含举牌梯度、意图倾向（财务 vs 战略）、6 个月锁定期、逼近举牌线观察名单。剔除通道账户与股本稀释造成的假举牌。BUILD 型 skill，可被复盘 agent 或事件驱动 Alpha 调用。",
+      "summary_zh": "举牌行为监控——侦测 A 股股东持股比例上穿 5%/10%/15%/20%/25%/30% 法定披露梯度的权益变动事件，含举牌梯度、意图倾向（财务 vs 战略）、6 个月锁定期、逼近举牌线观察名单。剔除通道账户与股本稀释造成的假举牌。BUILD 型 skill，可被复盘 agent 或事件驱动 Alpha 调用。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-equity-placard-watchlist",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
           "reporting"
         ]
       }
@@ -2216,6 +3168,45 @@
         "workflow_stages": [
           "data-ingestion",
           "monitoring",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "06",
+        "subcategory": "06.investor-research-models"
+      },
+      "catalog_status": "approved",
+      "category": "06",
+      "commit_sha": "c5841918a48d8beb24434454526cdc93839de753",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "每日盘后 ETF 资金流雷达 —— 用户问「今天/最近 ETF 有什么异动」「ETF 资金流看下」「哪些 ETF 在被大量申购/赎回」「ETF 净申赎异动」类问题时触发。扫描主流权益 ETF，输出三类信号（净申赎异动 / 折溢价背离 / 连续多日大额同向），以「样式② 结构化播报」呈现给用户。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-etf-flow-radar",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "06.investor-research-models",
+      "summary_en": "每日盘后 ETF 资金流雷达 —— 用户问「今天/最近 ETF 有什么异动」「ETF 资金流看下」「哪些 ETF 在被大量申购/赎回」「ETF 净申赎异动」类问题时触发。扫描主流权益 ETF，输出三类信号（净申赎异动 / 折溢价背离 / 连续多日大额同向），以「样式② 结构化播报」呈现给用户。",
+      "summary_zh": "每日盘后 ETF 资金流雷达 —— 用户问「今天/最近 ETF 有什么异动」「ETF 资金流看下」「哪些 ETF 在被大量申购/赎回」「ETF 净申赎异动」类问题时触发。扫描主流权益 ETF，输出三类信号（净申赎异动 / 折溢价背离 / 连续多日大额同向），以「样式② 结构化播报」呈现给用户。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-etf-flow-radar",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
           "reporting"
         ]
       }
@@ -2570,6 +3561,58 @@
     {
       "catalog": {
         "category": "02",
+        "subcategory": "02.factor-evaluation"
+      },
+      "catalog_status": "approved",
+      "category": "02",
+      "commit_sha": "384fadbb78e476649cc12aa856f6908769f1a205",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Diagnose factor predictive-power decay via daily Spearman IC, ICIR, Newey-West significance, rolling stability, and multi-horizon half-life. Evidence-first, no signals. Use when the user asks 因子IC衰减, IC半衰期, 因子稳不稳, ICIR, 预测力衰退, or 因子还能用多久, on Claude Code, Codex, Cursor, Hermes, or OpenClaw.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-factor-ic-decay",
+      "platforms": [
+        "claude-code",
+        "codex",
+        "cursor",
+        "hermes",
+        "openclaw"
+      ],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "evaluation",
+      "status": "stable",
+      "subcategory": "02.factor-evaluation",
+      "summary_en": "Diagnose factor IC decay, ICIR, significance, rolling stability, and multi-horizon half-life. Evidence-first, no trading signals.",
+      "summary_zh": "用日度截面 Spearman IC、ICIR、Newey-West 显著性、滚动稳定性与多周期半衰期，诊断因子预测力衰减；事实优先，不给买卖指令。",
+      "tags": [
+        "factor-ic",
+        "ic-decay",
+        "half-life",
+        "icir",
+        "factor-research"
+      ],
+      "url": "https://github.com/quantskills/skill-factor-ic-decay",
+      "validation_level": "runnable",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "factor-generation",
+          "evaluation"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "02",
         "subcategory": "02.factor-idea-generation"
       },
       "catalog_status": "approved",
@@ -2601,6 +3644,59 @@
         "primary_stage": "factor-generation",
         "workflow_stages": [
           "factor-generation"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "02",
+        "subcategory": "02.factor-generation"
+      },
+      "catalog_status": "approved",
+      "category": "02",
+      "commit_sha": "83cbeb00012a49ecdb2de7d41efc474f14dcc045",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Closed-loop factor evolution system: validate, backtest, diagnose, learn, generate variants, repeat for N iterations. Factors evolve through controlled transformations toward higher Sharpe. Use when iteratively optimizing alpha factors from candidate expressions and trading/backtest diagnostics.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-factor-loop-evolve",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [
+        "skill-pandadata-api"
+      ],
+      "stage": "evaluation",
+      "status": "draft",
+      "subcategory": "02.factor-generation",
+      "summary_en": "Local closed-loop factor research: generate, validate, backtest, diagnose, learn, iterate N rounds. Self-improving alpha discovery and optimization.",
+      "summary_zh": "本地闭环因子研究系统：生成导入因子，验证，回测（PandaData真实A股数据），诊断，优化，经验记忆，生成新批次，迭代N轮，实现自我改进的因子发现与优化。",
+      "tags": [
+        "factor-optimization",
+        "closed-loop",
+        "backtest",
+        "factor-validation",
+        "experience-memory",
+        "iterative-improvement",
+        "alpha-discovery",
+        "factor-diagnosis",
+        "self-improving",
+        "genetic-optimization"
+      ],
+      "url": "https://github.com/quantskills/skill-factor-loop-evolve",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "factor-generation",
+          "evaluation"
         ]
       }
     },
@@ -3032,6 +4128,57 @@
       },
       "catalog_status": "approved",
       "category": "02",
+      "commit_sha": "5bbb00a244f2e1330894d3c7fcb016d5c98b9954",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Generate alpha factor expressions from fundamental data (financial statements, valuation ratios, cash-flow derivatives, earnings forecasts, and ownership signals) using only PandaData (panda_data). Takes a research document, URL, or natural language query as input — or lets the model invent from a trading paradigm — and produces validated point-in-time alpha expressions backed by a formula contract. Use when an agent needs to generate alpha ideas from academic papers, market commentary, research notes, or its own invention in value, quality, growth, cash-flow, forecast, or ownership factor styles.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-fundamental-alpha",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "evaluation",
+      "status": "draft",
+      "subcategory": "02.factor-generation",
+      "summary_en": "Generate alpha factor expressions from fundamental data (PandaData). Accepts a document, URL, natural language query, or model invention and returns validated point-in-time factors.",
+      "summary_zh": "基于基本面数据（PandaData）生成Alpha因子表达式，支持从研报/自然语言输入中提取估值、质量、成长、现金流、预期与股东信号，并通过公式合约与PIT面板验证。",
+      "tags": [
+        "fundamental-data",
+        "financial-statements",
+        "alpha-generation",
+        "factor-discovery",
+        "point-in-time",
+        "value-investing",
+        "quality",
+        "pandadata",
+        "a-shares",
+        "ownership-signals"
+      ],
+      "url": "https://github.com/quantskills/skill-fundamental-alpha",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "factor-generation",
+          "evaluation"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "02",
+        "subcategory": "02.factor-generation"
+      },
+      "catalog_status": "approved",
+      "category": "02",
       "commit_sha": "6e34aa7bee6bbbe534b40a21ce1fe537187eac8a",
       "declaration_file": "SKILL.md",
       "declaration_status": "legacy",
@@ -3059,6 +4206,63 @@
         "primary_stage": "factor-generation",
         "workflow_stages": [
           "data-ingestion",
+          "factor-generation",
+          "evaluation"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "02",
+        "subcategory": "02.factor-evaluation"
+      },
+      "catalog_status": "approved",
+      "category": "02",
+      "commit_sha": "a9c1feddaec41984d58e8a15ae5678743c769c2a",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Commodity-futures CTA factor library — computes a structured date×variety factor panel (time-series & cross-sectional momentum, carry/roll, term structure, positioning/COT, inventory, volatility). Use when the user asks for 商品期货因子、 CTA 信号、动量/carry/期限结构/库存/持仓因子, a factor panel for futures backtesting, or futures factor IC. Fills the ecosystem gap of ZERO futures factor libraries (vs 10 for equities). Emits factor values for the factor toolchain (factor-evaluate / ic-analysis / backtest), NOT human-readable reports.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-futures-cta-alpha",
+      "platforms": [
+        "claude-code",
+        "codex",
+        "hermes",
+        "openclaw",
+        "cursor"
+      ],
+      "project_type": "skill",
+      "requires": [
+        "skill-pandadata-api"
+      ],
+      "stage": "evaluation",
+      "status": "stable",
+      "subcategory": "02.factor-evaluation",
+      "summary_en": "Commodity-futures CTA factor library — computes a structured date×variety factor panel (time-series & cross-sectional momentum, carry/roll, term structure, positioning/COT, inventory, volatility). Use when the user asks for 商品期货因子、 CTA 信号、动量/carry/期限结构/库存/持仓因子, a factor panel for futures backtesting, or futures factor IC. Fills the ecosystem gap of ZERO futures factor libraries (vs 10 for equities). Emits factor values for the factor toolchain (factor-evaluate / ic-analysis / backtest), NOT human-readable reports.",
+      "summary_zh": "Commodity-futures CTA factor library — computes a structured date×variety factor panel (time-series & cross-sectional momentum, carry/roll, term structure, positioning/COT, inventory, volatility). Use when the user asks for 商品期货因子、 CTA 信号、动量/carry/期限结构/库存/持仓因子, a factor panel for futures backtesting, or futures factor IC. Fills the ecosystem gap of ZERO futures factor libraries (vs 10 for equities). Emits factor values for the factor toolchain (factor-evaluate / ic-analysis / backtest), NOT human-readable reports.",
+      "tags": [
+        "futures",
+        "commodity",
+        "cta",
+        "factor-library",
+        "momentum",
+        "carry",
+        "term-structure",
+        "pandadata"
+      ],
+      "url": "https://github.com/quantskills/skill-futures-cta-alpha",
+      "validation_level": "runnable",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
           "factor-generation",
           "evaluation"
         ]
@@ -3104,6 +4308,84 @@
     },
     {
       "catalog": {
+        "category": "03",
+        "subcategory": "03.futures-commodity"
+      },
+      "catalog_status": "approved",
+      "category": "03",
+      "commit_sha": "89c447a7d5256c505e325b90c7897ba83774a606",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "当需要设计、审查或排错期货对冲、期货仓位 sizing、合约移仓、基差/carry 分析、日历价差、保证金压力测试或 CTA 风格期货配置时，使用此 skill。适用于股指期货、商品期货、利率期货和跨期价差场景，重点处理合约乘数、名义本金、保证金、期限结构、交割规则和压力损失。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-futures-hedgecraft",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "03.futures-commodity",
+      "summary_en": "当需要设计、审查或排错期货对冲、期货仓位 sizing、合约移仓、基差/carry 分析、日历价差、保证金压力测试或 CTA 风格期货配置时，使用此 skill。适用于股指期货、商品期货、利率期货和跨期价差场景，重点处理合约乘数、名义本金、保证金、期限结构、交割规则和压力损失。",
+      "summary_zh": "当需要设计、审查或排错期货对冲、期货仓位 sizing、合约移仓、基差/carry 分析、日历价差、保证金压力测试或 CTA 风格期货配置时，使用此 skill。适用于股指期货、商品期货、利率期货和跨期价差场景，重点处理合约乘数、名义本金、保证金、期限结构、交割规则和压力损失。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-futures-hedgecraft",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "03",
+        "subcategory": "03.futures-commodity"
+      },
+      "catalog_status": "approved",
+      "category": "03",
+      "commit_sha": "7a056483143649eee38719535e313db51217c66e",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Futures research Skill for analyzing, comparing, and screening futures markets with technical indicators, futures structure, and committee-style reports. Use when Codex needs to analyze a futures symbol, compare futures symbols, screen futures candidates, explain signal changes, or generate a structured futures research report without stock analysis, auto-trading, or deterministic buy/sell promises.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-futures-investment-council",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "03.futures-commodity",
+      "summary_en": "Futures research Skill for analyzing, comparing, and screening futures markets with technical indicators, futures structure, and committee-style reports. Use when Codex needs to analyze a futures symbol, compare futures symbols, screen futures candidates, explain signal changes, or generate a structured futures research report without stock analysis, auto-trading, or deterministic buy/sell promises.",
+      "summary_zh": "Futures research Skill for analyzing, comparing, and screening futures markets with technical indicators, futures structure, and committee-style reports. Use when Codex needs to analyze a futures symbol, compare futures symbols, screen futures candidates, explain signal changes, or generate a structured futures research report without stock analysis, auto-trading, or deterministic buy/sell promises.",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-futures-investment-council",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
         "category": "01",
         "subcategory": "01.market-data-governance"
       },
@@ -3139,6 +4421,58 @@
           "data-quality",
           "evaluation",
           "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "02",
+        "subcategory": "02.factor-generation"
+      },
+      "catalog_status": "approved",
+      "category": "02",
+      "commit_sha": "70fdb397efecf67cdf8e8fe0f90da87744b5d51f",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Build an auditable cross-sectional futures factor from contract-level open-interest concentration, volume concentration, and confirmed dominant-contract migration. Use when an agent needs to compute point-in-time transition and crowding features from direct PandaData futures data, produce factor values and roll-ledger evidence, or prepare a handoff to an existing factor-evaluation or backtest workflow. Do not use this skill for broker DeepView reports, generic carry or term-structure research, continuous-contract auditing, portfolio optimization, or trading instructions.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-futures-transition-crowding-factor",
+      "platforms": [
+        "claude-code",
+        "codex",
+        "openclaw",
+        "cursor",
+        "hermes"
+      ],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "evaluation",
+      "status": "draft",
+      "subcategory": "02.factor-generation",
+      "summary_en": "Build an auditable futures factor from contract transitions and crowding shifts",
+      "summary_zh": "从期货合约迁移与拥挤转移构造可审计横截面因子",
+      "tags": [
+        "futures-factor",
+        "crowding",
+        "contract-transition",
+        "open-interest",
+        "roll-ledger"
+      ],
+      "url": "https://github.com/quantskills/skill-futures-transition-crowding-factor",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "factor-generation",
+          "evaluation"
         ]
       }
     },
@@ -3335,6 +4669,144 @@
     {
       "catalog": {
         "category": "03",
+        "subcategory": "03.a-share-equity"
+      },
+      "catalog_status": "approved",
+      "category": "03",
+      "commit_sha": "8eab8d25d5147c23d5839d87c80224353a42f4b8",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "当需要开发、计算、验证 Graham 净净营运资本(NCAV) 因子时，使用此 skill。适用于 A 股全市场深度价值筛选，排除银行/房地产/非银金融，计算 NCAV 折价因子并生成 buy/sell/hold 信号。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-graham-netnet-screener",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "03.a-share-equity",
+      "summary_en": "当需要开发、计算、验证 Graham 净净营运资本(NCAV) 因子时，使用此 skill。适用于 A 股全市场深度价值筛选，排除银行/房地产/非银金融，计算 NCAV 折价因子并生成 buy/sell/hold 信号。",
+      "summary_zh": "当需要开发、计算、验证 Graham 净净营运资本(NCAV) 因子时，使用此 skill。适用于 A 股全市场深度价值筛选，排除银行/房地产/非银金融，计算 NCAV 折价因子并生成 buy/sell/hold 信号。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-graham-netnet-screener",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "02",
+        "subcategory": "02.factor-generation"
+      },
+      "catalog_status": "approved",
+      "category": "02",
+      "commit_sha": "e7cf9a0a378f648819172bb66a73532cb9afe807",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Build auditable equity factors by filtering predeclared PandaData factor channels over point-in-time industry and concept graphs. Use when an agent needs to measure graph-wide diffusion, local residuals, lagged neighbor propagation, or price-liquidity disagreement from a date-by-symbol factor panel. Do not use this skill to train graph neural networks, search arbitrary factor fields, reconstruct future graph membership, run portfolio backtests, or issue investment advice.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-graph-spectral-diffusion-factor",
+      "platforms": [
+        "claude-code",
+        "codex",
+        "openclaw",
+        "cursor",
+        "hermes"
+      ],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "evaluation",
+      "status": "draft",
+      "subcategory": "02.factor-generation",
+      "summary_en": "Build auditable factor diffusion and residuals on point-in-time equity graphs",
+      "summary_zh": "在点时股票关系图上构造可审计的因子扩散与局部残差",
+      "tags": [
+        "graph-signal-processing",
+        "diffusion-factor",
+        "spectral-filter",
+        "pandadata",
+        "point-in-time"
+      ],
+      "url": "https://github.com/quantskills/skill-graph-spectral-diffusion-factor",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "factor-generation",
+          "evaluation"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "04",
+        "subcategory": "04.portfolio-stress"
+      },
+      "catalog_status": "approved",
+      "category": "04",
+      "commit_sha": "184a346d018e964ec39c71cff84c588d8c692b01",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "A-share cumulative guarantee risk scanning skill for Pandadata-based monitoring of stock guarantee ratios, excess guarantee amounts, and high-debt-ratio guarantee exposure. Use when the user asks to scan A-share holdings for guarantee risks, monitor cumulative guarantee ratios, flag excess guarantee events, generate guarantee risk reports, or schedule recurring guarantee risk scans.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-guarantee-risk-scan",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [
+        "skill-pandadata-api"
+      ],
+      "stage": "reporting",
+      "status": "draft",
+      "subcategory": "04.portfolio-stress",
+      "summary_en": "A-share cumulative guarantee risk scanning: guarantee ratio, excess guarantee, and high-debt-ratio guarantee monitoring and alerting.",
+      "summary_zh": "A 股累计担保风险扫描：担保比率、超额担保、高负债率担保占比监控与预警报告。",
+      "tags": [
+        "a-share",
+        "guarantee-risk",
+        "monitoring",
+        "pandadata"
+      ],
+      "url": "https://github.com/quantskills/skill-guarantee-risk-scan",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "risk",
+          "monitoring",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "03",
         "subcategory": "03.hk-us-equity"
       },
       "catalog_status": "approved",
@@ -3487,6 +4959,46 @@
     },
     {
       "catalog": {
+        "category": "02",
+        "subcategory": "02.factor-generation"
+      },
+      "catalog_status": "approved",
+      "category": "02",
+      "commit_sha": "612027ff14cd0aefd0027f4f322af4907d68de3c",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Build, standardize, compare, and validate multi-factor fundamental panels for Hong Kong and US equities from PandaAI operating, market-financial, industry-median, price-volume, and financial-statement APIs. Use for quality, value, growth, momentum, low-risk, composite-score, percentile-rank, or cross-market stock-screening tasks.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-hk-us-fundamental-factor",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "evaluation",
+      "status": "active",
+      "subcategory": "02.factor-generation",
+      "summary_en": "Build, standardize, compare, and validate multi-factor fundamental panels for Hong Kong and US equities from PandaAI operating, market-financial, industry-median, price-volume, and financial-statement APIs. Use for quality, value, growth, momentum, low-risk, composite-score, percentile-rank, or cross-market stock-screening tasks.",
+      "summary_zh": "Build, standardize, compare, and validate multi-factor fundamental panels for Hong Kong and US equities from PandaAI operating, market-financial, industry-median, price-volume, and financial-statement APIs. Use for quality, value, growth, momentum, low-risk, composite-score, percentile-rank, or cross-market stock-screening tasks.",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-hk-us-fundamental-factor",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "factor-generation",
+          "evaluation"
+        ]
+      }
+    },
+    {
+      "catalog": {
         "category": "03",
         "subcategory": "03.hk-us-equity"
       },
@@ -3520,6 +5032,45 @@
         "workflow_stages": [
           "data-ingestion",
           "monitoring",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "03",
+        "subcategory": "03.hk-us-equity"
+      },
+      "catalog_status": "approved",
+      "category": "03",
+      "commit_sha": "1e68ec5b50d6fb6158afd9899923e7c7fb9a34ae",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Build, compare, and validate institutional ownership structure panels for Hong Kong and US equities with PandaAI investor concentration, ranking, and shareholder-report APIs. Use for ownership breadth, top-holder dominance, HHI, controlling-holder risk, evidence confidence, or within-market institutional ownership screening.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-hk-us-institutional-concentration",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "03.hk-us-equity",
+      "summary_en": "Build, compare, and validate institutional ownership structure panels for Hong Kong and US equities with PandaAI investor concentration, ranking, and shareholder-report APIs. Use for ownership breadth, top-holder dominance, HHI, controlling-holder risk, evidence confidence, or within-market institutional ownership screening.",
+      "summary_zh": "Build, compare, and validate institutional ownership structure panels for Hong Kong and US equities with PandaAI investor concentration, ranking, and shareholder-report APIs. Use for ownership breadth, top-holder dominance, HHI, controlling-holder risk, evidence confidence, or within-market institutional ownership screening.",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-hk-us-institutional-concentration",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
           "reporting"
         ]
       }
@@ -3959,6 +5510,125 @@
     },
     {
       "catalog": {
+        "category": "06",
+        "subcategory": "06.investor-research-models"
+      },
+      "catalog_status": "approved",
+      "category": "06",
+      "commit_sha": "d42a44234df4127419703eece171043c410404e8",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "用截图或只读 PandaData 行情识别股票/期货K线趋势结构、蜡烛线和候选图表形态，支持日线与1/5/10/15/30/60分钟线，输出证据、确认条件、失效条件和不确定性。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-kline-pattern-vision",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "06.investor-research-models",
+      "summary_en": "用截图或只读 PandaData 行情识别股票/期货K线趋势结构、蜡烛线和候选图表形态，支持日线与1/5/10/15/30/60分钟线，输出证据、确认条件、失效条件和不确定性。",
+      "summary_zh": "用截图或只读 PandaData 行情识别股票/期货K线趋势结构、蜡烛线和候选图表形态，支持日线与1/5/10/15/30/60分钟线，输出证据、确认条件、失效条件和不确定性。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-kline-pattern-vision",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "02",
+        "subcategory": "02.factor-generation"
+      },
+      "catalog_status": "approved",
+      "category": "02",
+      "commit_sha": "c92effa9c8e0b74230b22f96eac3cc19b158ac77",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Mine formulaic alpha factors end to end: LLM 主导生成候选公式 → 三层校验（白名单/量纲/前视）→ warm-start 遗传编程精修 → AlphaEval 五维打分 → LLM 经济解释 → 自包含 HTML 报告，返回结构化因子结果。Use when the user wants to mine/discover alpha factors, generate formulaic (expression-tree) trading factors, run LLM+GP factor search, or evaluate factor predictive power (RankIC) on stocks or futures. 只挖因子、不做回测（回测归另一 skill）。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-llm-alpha-generator",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "evaluation",
+      "status": "active",
+      "subcategory": "02.factor-generation",
+      "summary_en": "Mine formulaic alpha factors end to end: LLM 主导生成候选公式 → 三层校验（白名单/量纲/前视）→ warm-start 遗传编程精修 → AlphaEval 五维打分 → LLM 经济解释 → 自包含 HTML 报告，返回结构化因子结果。Use when the user wants to mine/discover alpha factors, generate formulaic (expression-tree) trading factors, run LLM+GP factor search, or evaluate factor predictive power (RankIC) on stocks or futures. 只挖因子、不做回测（回测归另一 skill）。",
+      "summary_zh": "Mine formulaic alpha factors end to end: LLM 主导生成候选公式 → 三层校验（白名单/量纲/前视）→ warm-start 遗传编程精修 → AlphaEval 五维打分 → LLM 经济解释 → 自包含 HTML 报告，返回结构化因子结果。Use when the user wants to mine/discover alpha factors, generate formulaic (expression-tree) trading factors, run LLM+GP factor search, or evaluate factor predictive power (RankIC) on stocks or futures. 只挖因子、不做回测（回测归另一 skill）。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-llm-alpha-generator",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "factor-generation",
+          "evaluation"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "06",
+        "subcategory": "06.statistical-ml-models"
+      },
+      "catalog_status": "approved",
+      "category": "06",
+      "commit_sha": "5deec2cc446f44bbc916c851f0d43e8a67317288",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "财报公告 RAG 问答系统——就一家 A 股公司的财报/公告提问，给出带官方引用、可核对、拒绝编造的回答。三路路由（数字精确算 / 底仓文本检索 / 官方全文按需）+ 引用纪律 + 拒答。数据源 PandaData 优先、官方披露网页为次级源。BUILD 型 skill，可被复盘 agent 或投研 agent 调用。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-llm-rag-financial-qa",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "evaluation",
+      "status": "active",
+      "subcategory": "06.statistical-ml-models",
+      "summary_en": "财报公告 RAG 问答系统——就一家 A 股公司的财报/公告提问，给出带官方引用、可核对、拒绝编造的回答。三路路由（数字精确算 / 底仓文本检索 / 官方全文按需）+ 引用纪律 + 拒答。数据源 PandaData 优先、官方披露网页为次级源。BUILD 型 skill，可被复盘 agent 或投研 agent 调用。",
+      "summary_zh": "财报公告 RAG 问答系统——就一家 A 股公司的财报/公告提问，给出带官方引用、可核对、拒绝编造的回答。三路路由（数字精确算 / 底仓文本检索 / 官方全文按需）+ 引用纪律 + 拒答。数据源 PandaData 优先、官方披露网页为次级源。BUILD 型 skill，可被复盘 agent 或投研 agent 调用。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-llm-rag-financial-qa",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "modeling",
+          "evaluation"
+        ]
+      }
+    },
+    {
+      "catalog": {
         "category": "05",
         "subcategory": "05.strategy-signal"
       },
@@ -4032,6 +5702,45 @@
         "workflow_stages": [
           "data-ingestion",
           "feature-engineering",
+          "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "03",
+        "subcategory": "03.macro-cross-asset"
+      },
+      "catalog_status": "approved",
+      "category": "03",
+      "commit_sha": "6f9fd7d0699ef99fa567e5d6b694cd57696dc643",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "基于 PandaData 的宏观事件—期货预期分析：读取宏观经济日历的实际值、市场预期与前值，结合期货价格、成交量、持仓量、基差、期限结构、库存与仓单，对沪金、沪铜、原油及用户指定品种输出基准、偏强、偏弱情景。当用户询问「美国CPI对期货影响」「宏观事件期货预期」「美联储对商品影响」「期货供需与宏观共振」「事件公布前情景」时触发。仅作条件化研究，不承诺涨跌或生成自动交易指令。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-macro-futures-scenario-analysis",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "03.macro-cross-asset",
+      "summary_en": "基于 PandaData 的宏观事件—期货预期分析：读取宏观经济日历的实际值、市场预期与前值，结合期货价格、成交量、持仓量、基差、期限结构、库存与仓单，对沪金、沪铜、原油及用户指定品种输出基准、偏强、偏弱情景。当用户询问「美国CPI对期货影响」「宏观事件期货预期」「美联储对商品影响」「期货供需与宏观共振」「事件公布前情景」时触发。仅作条件化研究，不承诺涨跌或生成自动交易指令。",
+      "summary_zh": "基于 PandaData 的宏观事件—期货预期分析：读取宏观经济日历的实际值、市场预期与前值，结合期货价格、成交量、持仓量、基差、期限结构、库存与仓单，对沪金、沪铜、原油及用户指定品种输出基准、偏强、偏弱情景。当用户询问「美国CPI对期货影响」「宏观事件期货预期」「美联储对商品影响」「期货供需与宏观共振」「事件公布前情景」时触发。仅作条件化研究，不承诺涨跌或生成自动交易指令。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-macro-futures-scenario-analysis",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
           "modeling",
           "reporting"
         ]
@@ -4158,6 +5867,133 @@
     {
       "catalog": {
         "category": "02",
+        "subcategory": "02.factor-generation"
+      },
+      "catalog_status": "approved",
+      "category": "02",
+      "commit_sha": "6d859ee20d3309d340ae00b00ed86bd866c25271",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "A-share material contract alpha factor skill — generates trading signals based on major contract announcements. Use when the user asks to calculate material contract alpha, generate contract-based signals, scan for recent major contract announcements, or evaluate contract-driven trading opportunities.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-material-contract-alpha",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [
+        "skill-pandadata-api"
+      ],
+      "stage": "evaluation",
+      "status": "draft",
+      "subcategory": "02.factor-generation",
+      "summary_en": "A-share material contract alpha factor: cross-sectional ranking based on log-sum of contract amounts.",
+      "summary_zh": "A 股重大合同 Alpha 因子：基于合同金额对数和的横截面排序信号。",
+      "tags": [
+        "a-share",
+        "alpha",
+        "material-contract",
+        "factor",
+        "pandadata"
+      ],
+      "url": "https://github.com/quantskills/skill-material-contract-alpha",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "factor-generation",
+          "evaluation"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "05",
+        "subcategory": "05.market-microstructure"
+      },
+      "catalog_status": "approved",
+      "category": "05",
+      "commit_sha": "f9e7fbe6a173063f364bdc435ce3d8d778324872",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Minute-bar VWAP deviation strategy research and auditable SSQuant futures validation. Use for rolling VWAP deviation signals, confirmed mean reversion, trend guards, next-bar execution, execution-cost modeling, frozen-data backtests, and trade-result review.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-microstructure-vwap-deviation",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "05.market-microstructure",
+      "summary_en": "Minute-bar VWAP deviation strategy research and auditable SSQuant futures validation. Use for rolling VWAP deviation signals, confirmed mean reversion, trend guards, next-bar execution, execution-cost modeling, frozen-data backtests, and trade-result review.",
+      "summary_zh": "Minute-bar VWAP deviation strategy research and auditable SSQuant futures validation. Use for rolling VWAP deviation signals, confirmed mean reversion, trend guards, next-bar execution, execution-cost modeling, frozen-data backtests, and trade-result review.",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-microstructure-vwap-deviation",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "02",
+        "subcategory": "02.factor-generation"
+      },
+      "catalog_status": "approved",
+      "category": "02",
+      "commit_sha": "a44602c187ec01d6f69bbc0d69e2b388e06bb5f4",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Generate alpha factor expressions from minute-level market data using PandaData (panda_data). Takes a research document or natural language query as input, fetches intraday OHLCV bars via get_market_min_data, extracts rich minute-level features (VWAP divergence, intraday momentum decay, order flow proxy, volatility curve shape, trade concentration, lead-lag signatures), and produces validated alpha expressions backed by a formula contract. Use when an agent needs to generate alpha ideas from academic papers, market commentary, or research notes that leverage intraday microstructure signals invisible in daily data.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-minuteflow-alpha",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "evaluation",
+      "status": "draft",
+      "subcategory": "02.factor-generation",
+      "summary_en": "Generate alpha factor expressions from minute-level market data using PandaData (panda_data). Takes a research document or natural language query as input, fetches intraday OHLCV bars via get_market_min_data, extracts rich minute-level features (VWAP divergence, intraday momentum decay, order flow proxy, volatility curve shape, trade concentration, lead-lag signatures), and produces validated alpha expressions backed by a formula contract. Use when an agent needs to generate alpha ideas from academic papers, market commentary, or research notes that leverage intraday microstructure signals invisible in daily data.",
+      "summary_zh": "基于分钟级行情数据（PandaData）生成Alpha因子表达式，支持从研报/自然语言输入中提取日内微观结构信号（VWAP偏离、订单流代理、日内动量衰减、波动率曲线等），并通过公式合约验证。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-minuteflow-alpha",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "factor-generation",
+          "evaluation"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "02",
         "subcategory": "02.factor-orthogonalization-blending"
       },
       "catalog_status": "approved",
@@ -4192,6 +6028,46 @@
           "factor-generation",
           "modeling",
           "backtesting",
+          "evaluation"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "06",
+        "subcategory": "06.statistical-ml-models"
+      },
+      "catalog_status": "approved",
+      "category": "06",
+      "commit_sha": "362893c4ae20edf62836670eee753baa67490e2e",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "审计任意金融特征、可训练时序模型或候选策略收益，并执行防泄漏的 Purged K-Fold、Embargo、CPCV、Causal Walk-Forward、PBO、DSR、Governed Holdout 与 Temporal Forward Evidence。用于检查未来函数、信息区间重叠、特征可用时间和血缘、Fold-Local 预处理、CPCV Path 稳健性、策略选择过拟合、预测是否在标签成熟前登记，以及在接受金融模型或策略前生成结构化验证证据。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-ml-purged-cv",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "evaluation",
+      "status": "active",
+      "subcategory": "06.statistical-ml-models",
+      "summary_en": "审计任意金融特征、可训练时序模型或候选策略收益，并执行防泄漏的 Purged K-Fold、Embargo、CPCV、Causal Walk-Forward、PBO、DSR、Governed Holdout 与 Temporal Forward Evidence。用于检查未来函数、信息区间重叠、特征可用时间和血缘、Fold-Local 预处理、CPCV Path 稳健性、策略选择过拟合、预测是否在标签成熟前登记，以及在接受金融模型或策略前生成结构化验证证据。",
+      "summary_zh": "审计任意金融特征、可训练时序模型或候选策略收益，并执行防泄漏的 Purged K-Fold、Embargo、CPCV、Causal Walk-Forward、PBO、DSR、Governed Holdout 与 Temporal Forward Evidence。用于检查未来函数、信息区间重叠、特征可用时间和血缘、Fold-Local 预处理、CPCV Path 稳健性、策略选择过拟合、预测是否在标签成熟前登记，以及在接受金融模型或策略前生成结构化验证证据。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-ml-purged-cv",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "modeling",
           "evaluation"
         ]
       }
@@ -4428,6 +6304,58 @@
         "workflow_stages": [
           "data-ingestion",
           "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "02",
+        "subcategory": "02.factor-generation"
+      },
+      "catalog_status": "approved",
+      "category": "02",
+      "commit_sha": "29763e849a1b8a7d6f5194758a23714c4ad0c7c4",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Build auditable cross-sectional factors with one-dimensional optimal transport from point-in-time market panels. Use when an agent needs to compare weighted feature distributions across dates, compute Wasserstein displacement and transport-pressure features, construct global or industry-neutral panels, or prepare a deterministic handoff to factor evaluation. Do not use this skill to train black-box models, search arbitrary formulas, replace data APIs, backtest portfolios, or issue investment advice.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-optimal-transport-cross-sectional-factor",
+      "platforms": [
+        "claude-code",
+        "codex",
+        "openclaw",
+        "cursor",
+        "hermes"
+      ],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "evaluation",
+      "status": "draft",
+      "subcategory": "02.factor-generation",
+      "summary_en": "Build auditable factors from point-in-time cross-sectional transport",
+      "summary_zh": "用点时截面分布的单调最优传输构造可审计因子",
+      "tags": [
+        "optimal-transport",
+        "wasserstein",
+        "cross-sectional-factor",
+        "point-in-time",
+        "industry-neutral"
+      ],
+      "url": "https://github.com/quantskills/skill-optimal-transport-cross-sectional-factor",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "evaluation",
+        "workflow_stages": [
+          "data-ingestion",
+          "feature-engineering",
+          "factor-generation",
+          "evaluation"
         ]
       }
     },
@@ -4894,6 +6822,51 @@
     },
     {
       "catalog": {
+        "category": "06",
+        "subcategory": "06.investor-research-models"
+      },
+      "catalog_status": "approved",
+      "category": "06",
+      "commit_sha": "2beed86fe9c69fa12c2cee9bf36eb937d8194eb4",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Use when an agent needs to attribute the returns of an A-share quant strategy or portfolio — decompose performance into Alpha/Beta/timing, Brinson allocation/selection/interaction effects by industry, and factor-return contributions (style factors, industry, residual Alpha). Outputs a unified AttributionReport (Markdown + JSON) with reconciliation checks.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-performance-attribution",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "stable",
+      "subcategory": "06.investor-research-models",
+      "summary_en": "Use when an agent needs to attribute the returns of an A-share quant strategy or portfolio — decompose performance into Alpha/Beta/timing, Brinson allocation/selection/interaction effects by industry, and factor-return contributions (style factors, industry, residual Alpha). Outputs a unified AttributionReport (Markdown + JSON) with reconciliation checks.",
+      "summary_zh": "A股量化策略绩效归因：三层综合归因（Alpha/Beta/择时 + Brinson 配置/选择/交互 + 因子收益归因含风格行业与 Alpha 残差），输出统一归因报告并做分解对账。与 skill-risk-model（风险归因）互补。",
+      "tags": [
+        "performance-attribution",
+        "brinson",
+        "factor-attribution",
+        "alpha-beta",
+        "portfolio-analysis"
+      ],
+      "url": "https://github.com/quantskills/skill-performance-attribution",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
         "category": "05",
         "subcategory": "05.performance-attribution"
       },
@@ -4933,6 +6906,46 @@
     },
     {
       "catalog": {
+        "category": "05",
+        "subcategory": "05.portfolio-construction"
+      },
+      "catalog_status": "approved",
+      "category": "05",
+      "commit_sha": "cc4ec36956fdd123141557c922bc34dcd7600ab6",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Black-Litterman 组合优化 —— 用户问「跑一下 BL 组合」「基于视图的组合权重」「相对沪深300 的主动配置」「动量/反转/换手视图对权重的影响」类问题时触发。以沪深300 指数权重为先验，用动量/反转/换手率三条因子视图更新，输出长权重组合，按「样式② 结构化播报」呈现给用户。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-portfolio-blacklitterman",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "risk",
+      "status": "active",
+      "subcategory": "05.portfolio-construction",
+      "summary_en": "Black-Litterman 组合优化 —— 用户问「跑一下 BL 组合」「基于视图的组合权重」「相对沪深300 的主动配置」「动量/反转/换手视图对权重的影响」类问题时触发。以沪深300 指数权重为先验，用动量/反转/换手率三条因子视图更新，输出长权重组合，按「样式② 结构化播报」呈现给用户。",
+      "summary_zh": "Black-Litterman 组合优化 —— 用户问「跑一下 BL 组合」「基于视图的组合权重」「相对沪深300 的主动配置」「动量/反转/换手视图对权重的影响」类问题时触发。以沪深300 指数权重为先验，用动量/反转/换手率三条因子视图更新，输出长权重组合，按「样式② 结构化播报」呈现给用户。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-portfolio-blacklitterman",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "risk",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "portfolio-construction",
+          "risk"
+        ]
+      }
+    },
+    {
+      "catalog": {
         "category": "04",
         "subcategory": "04.portfolio-stress"
       },
@@ -4967,6 +6980,46 @@
           "data-ingestion",
           "risk",
           "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "05",
+        "subcategory": "05.portfolio-construction"
+      },
+      "catalog_status": "approved",
+      "category": "05",
+      "commit_sha": "ba87ca4932f39e21d58c4647a919422bcadfe2c3",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "当需要开发、计算、验证 CVaR 尾部风险最小化组合时，使用此 skill。在预期收益约束下最小化组合 95% CVaR，支持极值理论(EVT/GPD)尾部补样、组合权重求解、样本外验证。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-portfolio-cvar-optim",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "risk",
+      "status": "active",
+      "subcategory": "05.portfolio-construction",
+      "summary_en": "当需要开发、计算、验证 CVaR 尾部风险最小化组合时，使用此 skill。在预期收益约束下最小化组合 95% CVaR，支持极值理论(EVT/GPD)尾部补样、组合权重求解、样本外验证。",
+      "summary_zh": "当需要开发、计算、验证 CVaR 尾部风险最小化组合时，使用此 skill。在预期收益约束下最小化组合 95% CVaR，支持极值理论(EVT/GPD)尾部补样、组合权重求解、样本外验证。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-portfolio-cvar-optim",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "risk",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "portfolio-construction",
+          "risk"
         ]
       }
     },
@@ -5086,6 +7139,46 @@
           "data-ingestion",
           "evaluation",
           "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "05",
+        "subcategory": "05.portfolio-construction"
+      },
+      "catalog_status": "approved",
+      "category": "05",
+      "commit_sha": "ea2a22de1c66767e844d136b68d287806a43e00c",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "当需要开发、计算、验证风险平价（等风险贡献 ERC）组合时使用。手写 Ledoit-Wolf 收缩协方差稳定相关性，scipy SLSQP 求 ERC 权重，支持指数/期货/ETF 三类资产与月度 rebalance。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-portfolio-risk-parity",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "risk",
+      "status": "active",
+      "subcategory": "05.portfolio-construction",
+      "summary_en": "当需要开发、计算、验证风险平价（等风险贡献 ERC）组合时使用。手写 Ledoit-Wolf 收缩协方差稳定相关性，scipy SLSQP 求 ERC 权重，支持指数/期货/ETF 三类资产与月度 rebalance。",
+      "summary_zh": "当需要开发、计算、验证风险平价（等风险贡献 ERC）组合时使用。手写 Ledoit-Wolf 收缩协方差稳定相关性，scipy SLSQP 求 ERC 权重，支持指数/期货/ETF 三类资产与月度 rebalance。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-portfolio-risk-parity",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "risk",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "portfolio-construction",
+          "risk"
         ]
       }
     },
@@ -5447,42 +7540,54 @@
     },
     {
       "catalog": {
-        "category": "06",
-        "subcategory": "06.paper-replication"
+        "category": "02",
+        "subcategory": "02.factor-evaluation"
       },
       "catalog_status": "approved",
-      "category": "06",
-      "commit_sha": "0e41cf070091de7117bdb5be3b571e5571243641",
+      "category": "02",
+      "commit_sha": "46fb8aa255de5782e241601b2aeede70d6eb2174",
       "declaration_file": "SKILL.md",
       "declaration_status": "legacy",
       "default_branch": "main",
-      "description": "Search for quantitative finance papers or research reports, then reproduce them end to end: source discovery across arXiv/Crossref/Semantic Scholar/SSRN/NBER/RePEc/institutional reports/Chinese broker research, full Chinese translation, AI summary, factor formula reconstruction, factor effectiveness validation, standalone beginner-readable HTML factor report, BACKTEST strategy generation and local backtest execution, Chinese backtest explanation report, and final delivery summary. Use when the user asks to find quant papers/reports, replicate a report/PDF/link/text, validate a factor, generate BACKTEST strategy code, or create a beginner-readable research replication package.",
+      "description": "诊断量化策略或因子的近期表现是否恶化，并列出可验证的原因。用户提供因子/策略的周期收益，以及可选的 IC、基准收益、换手率或市场状态数据，要求检查滚动收益、回撤、IC 衰减、相对基准表现、换手变化、样本外稳定性或新旧版本差异时使用。适用于 PandaAI/Pandadata 的因子挖掘和回测结果；数据不足时只报告可计算部分和缺失字段，不给买卖建议。",
       "health": "frozen-declaration-only",
       "interface": null,
       "interface_status": "pending-maintainer",
-      "last_validated": "2026-08-11",
+      "last_validated": "2026-08-29",
       "license": "GPL-3.0-only",
       "maintainer_type": "community",
-      "name": "skill-quant-research-replication",
-      "platforms": [],
+      "name": "skill-quant-strategy-diagnostics",
+      "platforms": [
+        "claude-code",
+        "codex",
+        "cursor",
+        "hermes",
+        "openclaw"
+      ],
       "project_type": "skill",
       "requires": [],
-      "stage": "modeling",
-      "status": "active",
-      "subcategory": "06.paper-replication",
-      "summary_en": "Guides auditable quantitative-research replication workflows.",
-      "summary_zh": "指导可审计的量化研究复现流程。",
-      "tags": [],
-      "url": "https://github.com/quantskills/skill-quant-research-replication",
-      "validation_level": "listed",
+      "stage": "evaluation",
+      "status": "draft",
+      "subcategory": "02.factor-evaluation",
+      "summary_en": "Check recent strategy or factor deterioration using returns, IC, drawdown, turnover, benchmarks, and market regimes.",
+      "summary_zh": "检查策略或因子近期是否恶化，列出收益、IC、回撤、换手率和市场状态方面的证据。",
+      "tags": [
+        "strategy-diagnostics",
+        "factor-decay",
+        "drawdown",
+        "rolling-ic",
+        "backtest-validation",
+        "regime-analysis"
+      ],
+      "url": "https://github.com/quantskills/skill-quant-strategy-diagnostics",
+      "validation_level": "runnable",
       "workflow": {
-        "primary_stage": "modeling",
+        "primary_stage": "evaluation",
         "workflow_stages": [
           "data-ingestion",
-          "modeling",
-          "backtesting",
-          "evaluation",
-          "reporting"
+          "feature-engineering",
+          "factor-generation",
+          "evaluation"
         ]
       }
     },
@@ -5726,6 +7831,46 @@
     },
     {
       "catalog": {
+        "category": "05",
+        "subcategory": "05.portfolio-construction"
+      },
+      "catalog_status": "approved",
+      "category": "05",
+      "commit_sha": "b40f25acc4f26a042cc1667c7c6b23c8b5f2d115",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-rl-portfolio-allocator",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "risk",
+      "status": "active",
+      "subcategory": "05.portfolio-construction",
+      "summary_en": "skill rl portfolio allocator",
+      "summary_zh": "skill rl portfolio allocator",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-rl-portfolio-allocator",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "risk",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "portfolio-construction",
+          "risk"
+        ]
+      }
+    },
+    {
+      "catalog": {
         "category": "04",
         "subcategory": "04.portfolio-stress"
       },
@@ -5770,6 +7915,45 @@
       },
       "catalog_status": "approved",
       "category": "06",
+      "commit_sha": "a14e7fb69cd116d3068a66fb7eb95898001f518b",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "当需要分析市场状态、行业轮动、ETF 强弱排序、市场宽度、风格切换或战术配置信号时，使用此 skill。适用于 A 股、港股、美股和 ETF 池的行业轮动分析、risk-on/risk-off 状态识别、相对强弱排名、宽度确认、假突破过滤和轮动失效条件设计。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-rotation-radar",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "06.investor-research-models",
+      "summary_en": "当需要分析市场状态、行业轮动、ETF 强弱排序、市场宽度、风格切换或战术配置信号时，使用此 skill。适用于 A 股、港股、美股和 ETF 池的行业轮动分析、risk-on/risk-off 状态识别、相对强弱排名、宽度确认、假突破过滤和轮动失效条件设计。",
+      "summary_zh": "当需要分析市场状态、行业轮动、ETF 强弱排序、市场宽度、风格切换或战术配置信号时，使用此 skill。适用于 A 股、港股、美股和 ETF 池的行业轮动分析、risk-on/risk-off 状态识别、相对强弱排名、宽度确认、假突破过滤和轮动失效条件设计。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-rotation-radar",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "06",
+        "subcategory": "06.investor-research-models"
+      },
+      "catalog_status": "approved",
+      "category": "06",
       "commit_sha": "97896616e3704e374ae4f0dbda7a93cc349b11cb",
       "declaration_file": "SKILL.md",
       "declaration_status": "legacy",
@@ -5798,6 +7982,108 @@
         "workflow_stages": [
           "data-ingestion",
           "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "06",
+        "subcategory": "06.investor-research-models"
+      },
+      "catalog_status": "approved",
+      "category": "06",
+      "commit_sha": "fec65729f709ae291ce4c9fa9a24af6b0ad35edc",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Run and audit the Q58 five-session cross-sectional short-term return reversal factor on A-shares. Use when an agent needs 5-day loser-versus-winner signals, point-in-time factor snapshots, or a cost-aware mean-reversion research backtest.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-shortterm-mean-reversal",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "06.investor-research-models",
+      "summary_en": "Cost-aware A-share five-session cross-sectional return reversal research.",
+      "summary_zh": "A 股五交易日收益率横截面反转因子与成本敏感回测。",
+      "tags": [
+        "a-share",
+        "mean-reversion",
+        "short-term-reversal",
+        "point-in-time",
+        "backtest"
+      ],
+      "url": "https://github.com/quantskills/skill-shortterm-mean-reversal",
+      "validation_level": "runnable",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "05",
+        "subcategory": "05.portfolio-construction"
+      },
+      "catalog_status": "approved",
+      "category": "05",
+      "commit_sha": "b85dc0760ba9b36a4c10a8a8e108d7bf06e5c412",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Build an open Barra-style structural equity risk model and convert one frozen cross-sectional stock signal into benchmark-relative long-only target weights with auditable two-stage signal-capture, transaction-cost, exposure, turnover, tracking-error, and tradability controls. Use when Codex needs to optimize a LightGBM or single-factor stock signal, estimate or consume covariance, enforce market-cap, style, or point-in-time industry constraints, run a next-trading-day rolling portfolio study, or diagnose weights, risk, turnover, NAV, and drawdown results. Also use for Chinese requests such as 风险模型、协方差估计、信号组合优化、单因子权重优化、风险约束配权、行业风格中性、滚动优化、净值回撤、换手成本或优化前后回测对比.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-signal-portfolio-optimize",
+      "platforms": [
+        "cursor",
+        "claude-code",
+        "codex",
+        "hermes",
+        "openclaw"
+      ],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "portfolio-construction",
+      "status": "active",
+      "subcategory": "05.portfolio-construction",
+      "summary_en": "Converts one stock signal into benchmark-relative target weights with auditable risk, exposure, turnover, and cost controls.",
+      "summary_zh": "将单个股票信号转换为受基准相对风险、风格、行业、换手和成本约束的可审计组合权重。",
+      "tags": [
+        "portfolio-optimization",
+        "signal-optimization",
+        "risk-model",
+        "benchmark-relative",
+        "factor-model",
+        "risk-control",
+        "backtesting"
+      ],
+      "url": "https://github.com/quantskills/skill-signal-portfolio-optimize",
+      "validation_level": "runnable",
+      "workflow": {
+        "primary_stage": "portfolio-construction",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "risk",
+          "portfolio-construction",
+          "backtesting",
+          "evaluation",
           "reporting"
         ]
       }
@@ -5918,6 +8204,45 @@
         "workflow_stages": [
           "data-ingestion",
           "monitoring",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "03",
+        "subcategory": "03.a-share-equity"
+      },
+      "catalog_status": "approved",
+      "category": "03",
+      "commit_sha": "23141a47ba0c11761f0b333b70a0f73b13d749da",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "索罗斯反身性识别器——用双环模型（快环情绪-资金 / 慢环基本面-资本）判断 A 股\"这波涨跌是不是自我强化的反身性、转到哪一圈、燃料和裂缝在哪\"，做阶段识别与仓位纪律。BUILD 型 skill，可被复盘 agent 或 Alpha 调用。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-soros-reflexivity-detector",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "03.a-share-equity",
+      "summary_en": "索罗斯反身性识别器——用双环模型（快环情绪-资金 / 慢环基本面-资本）判断 A 股\"这波涨跌是不是自我强化的反身性、转到哪一圈、燃料和裂缝在哪\"，做阶段识别与仓位纪律。BUILD 型 skill，可被复盘 agent 或 Alpha 调用。",
+      "summary_zh": "索罗斯反身性识别器——用双环模型（快环情绪-资金 / 慢环基本面-资本）判断 A 股\"这波涨跌是不是自我强化的反身性、转到哪一圈、燃料和裂缝在哪\"，做阶段识别与仓位纪律。BUILD 型 skill，可被复盘 agent 或 Alpha 调用。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-soros-reflexivity-detector",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
           "reporting"
         ]
       }
@@ -6089,6 +8414,45 @@
       },
       "catalog_status": "approved",
       "category": "03",
+      "commit_sha": "5d25e6700438ade67b77a498cfd1d34b567acc80",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-stock-score",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "03.a-share-equity",
+      "summary_en": "skill stock score",
+      "summary_zh": "skill stock score",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-stock-score",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "03",
+        "subcategory": "03.a-share-equity"
+      },
+      "catalog_status": "approved",
+      "category": "03",
       "commit_sha": "8234c3fd2d2ba49ef505e249b572eac2fd008926",
       "declaration_file": "SKILL.md",
       "declaration_status": "legacy",
@@ -6117,6 +8481,105 @@
         "workflow_stages": [
           "data-ingestion",
           "factor-screening",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "05",
+        "subcategory": "05.transaction-costs"
+      },
+      "catalog_status": "approved",
+      "category": "05",
+      "commit_sha": "6ae79f729000f497674dd29e8a3689f816a33452",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "策略容量, 冲击成本, ADV参与率, TCA, 容量曲线, implementation shortfall style cost estimate. Estimate how much capital a strategy can take before costs eat alpha — participation vs ADV, square-root/linear impact, capacity curve and breakeven AUM. Evidence-first; impact model is an estimate not a guarantee; no trade advice. Use when the user asks 策略容量, 冲击成本, ADV参与率, TCA, 容量曲线, 交易成本吃掉多少alpha, or market impact / capacity analysis on Claude Code, Codex, Cursor, Hermes, or OpenClaw.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-strategy-capacity-tca",
+      "platforms": [
+        "claude-code",
+        "codex",
+        "cursor",
+        "hermes",
+        "openclaw"
+      ],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "stable",
+      "subcategory": "05.transaction-costs",
+      "summary_en": "Estimate strategy capacity and transaction costs from trades and ADV — participation, square-root/linear impact, capacity curve and breakeven vs alpha. Estimates only, no trade advice.",
+      "summary_zh": "用成交与 ADV 估计参与率、平方根/线性冲击成本与容量曲线，回答「策略能承载多少资金、成本何时吃掉 alpha」——估计非保证，不作交易建议。",
+      "tags": [
+        "capacity",
+        "tca",
+        "market-impact",
+        "turnover",
+        "liquidity"
+      ],
+      "url": "https://github.com/quantskills/skill-strategy-capacity-tca",
+      "validation_level": "runnable",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "evaluation",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "08",
+        "subcategory": "08.daily-review"
+      },
+      "catalog_status": "approved",
+      "category": "08",
+      "commit_sha": "938daeb1f960b681eb7394274234401aa033bc3e",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Use when an agent needs to generate a periodic performance report for a LIVE A-share quant strategy — 日报/周报/月报/半年报/年报 or custom period — covering returns, risk, trade analysis, and position/turnover detail, with embedded visualizations. Outputs a self-contained offline HTML dashboard (interactive ECharts) plus Markdown + JSON.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-strategy-performance-report",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "stable",
+      "subcategory": "08.daily-review",
+      "summary_en": "Use when an agent needs to generate a periodic performance report for a LIVE A-share quant strategy — 日报/周报/月报/半年报/年报 or custom period — covering returns, risk, trade analysis, and position/turnover detail, with embedded visualizations. Outputs a self-contained offline HTML dashboard (interactive ECharts) plus Markdown + JSON.",
+      "summary_zh": "Use when an agent needs to generate a periodic performance report for a LIVE A-share quant strategy — 日报/周报/月报/半年报/年报 or custom period — covering returns, risk, trade analysis, and position/turnover detail, with embedded visualizations. Outputs a self-contained offline HTML dashboard (interactive ECharts) plus Markdown + JSON.",
+      "tags": [
+        "performance-report",
+        "sharpe",
+        "drawdown",
+        "turnover",
+        "equity-curve",
+        "live-monitoring",
+        "visualization"
+      ],
+      "url": "https://github.com/quantskills/skill-strategy-performance-report",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "evaluation",
           "reporting"
         ]
       }
@@ -6239,6 +8702,45 @@
     },
     {
       "catalog": {
+        "category": "03",
+        "subcategory": "03.a-share-equity"
+      },
+      "catalog_status": "approved",
+      "category": "03",
+      "commit_sha": "81e7fbd8ab64dcb16ac17070c5fb88bbb4e9cdc9",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "当需要开发、计算、验证 Templeton 全球价值多因子 V2 时，使用此 skill。适用于 A 股/港股/美股跨市场价值筛选，基于 EP/BP/SP/股息/ROE/杠杆/动量 七子因子截面打分，生成 buy/sell/hold 信号。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-templeton-global-contrarian",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "03.a-share-equity",
+      "summary_en": "当需要开发、计算、验证 Templeton 全球价值多因子 V2 时，使用此 skill。适用于 A 股/港股/美股跨市场价值筛选，基于 EP/BP/SP/股息/ROE/杠杆/动量 七子因子截面打分，生成 buy/sell/hold 信号。",
+      "summary_zh": "当需要开发、计算、验证 Templeton 全球价值多因子 V2 时，使用此 skill。适用于 A 股/港股/美股跨市场价值筛选，基于 EP/BP/SP/股息/ROE/杠杆/动量 七子因子截面打分，生成 buy/sell/hold 信号。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-templeton-global-contrarian",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
         "category": "06",
         "subcategory": "06.statistical-ml-models"
       },
@@ -6272,6 +8774,90 @@
         "workflow_stages": [
           "data-ingestion",
           "modeling",
+          "evaluation",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "06",
+        "subcategory": "06.investor-research-models"
+      },
+      "catalog_status": "approved",
+      "category": "06",
+      "commit_sha": "8507fe4556c440a9f0700e954a35af03b502980c",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-tqx-research",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "06.investor-research-models",
+      "summary_en": "skill tqx research",
+      "summary_zh": "skill tqx research",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-tqx-research",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "08",
+        "subcategory": "08.daily-review"
+      },
+      "catalog_status": "approved",
+      "category": "08",
+      "commit_sha": "510f285a08c49a07829ced26c74189b8525e4e29",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "Reproduce daily or range-based trade review workflows end to end: normalize closed/open trades, pull market context, compute attribution and patterns, generate actionable advice, optionally call LLM for narrative review, and return a structured review result. Use when the user provides trade records and asks for a trade retrospective, post-trade diagnosis, mistake pattern detection, or execution/process advice.",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-trade-review",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "stable",
+      "subcategory": "08.daily-review",
+      "summary_en": "Trade review skill that turns trade records into attribution, pattern detection, per-trade review, and actionable advice.",
+      "summary_zh": "把交易流水转成结构化复盘结果，包含归因、逐笔点评、错误模式、建议和可选 LLM 总结。",
+      "tags": [
+        "trade-review",
+        "retrospective",
+        "pnl-attribution",
+        "market-context",
+        "chinese"
+      ],
+      "url": "https://github.com/quantskills/skill-trade-review",
+      "validation_level": "runnable",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
           "evaluation",
           "reporting"
         ]
@@ -6351,6 +8937,45 @@
         "workflow_stages": [
           "data-ingestion",
           "evaluation",
+          "reporting"
+        ]
+      }
+    },
+    {
+      "catalog": {
+        "category": "06",
+        "subcategory": "06.investor-research-models"
+      },
+      "catalog_status": "approved",
+      "category": "06",
+      "commit_sha": "0e33deadd53b2ad77127e3f05267d889dd152b50",
+      "declaration_file": "SKILL.md",
+      "declaration_status": "legacy",
+      "default_branch": "main",
+      "description": "计算A股日线下跌突破划线压力位反转因子，识别下破下降压力线后反转确认的个股；当用户提供交易日期、要求自动获取当日全市场A股行情、量化选股、因子研究或回测时使用。",
+      "health": "frozen-declaration-only",
+      "interface": null,
+      "interface_status": "pending-maintainer",
+      "last_validated": "2026-08-29",
+      "license": "GPL-3.0-only",
+      "maintainer_type": "community",
+      "name": "skill-trendline-breakdown-reversal",
+      "platforms": [],
+      "project_type": "skill",
+      "requires": [],
+      "stage": "reporting",
+      "status": "active",
+      "subcategory": "06.investor-research-models",
+      "summary_en": "计算A股日线下跌突破划线压力位反转因子，识别下破下降压力线后反转确认的个股；当用户提供交易日期、要求自动获取当日全市场A股行情、量化选股、因子研究或回测时使用。",
+      "summary_zh": "计算A股日线下跌突破划线压力位反转因子，识别下破下降压力线后反转确认的个股；当用户提供交易日期、要求自动获取当日全市场A股行情、量化选股、因子研究或回测时使用。",
+      "tags": [],
+      "url": "https://github.com/quantskills/skill-trendline-breakdown-reversal",
+      "validation_level": "listed",
+      "workflow": {
+        "primary_stage": "reporting",
+        "workflow_stages": [
+          "data-ingestion",
+          "modeling",
           "reporting"
         ]
       }

--- a/tests/readme-render.test.mjs
+++ b/tests/readme-render.test.mjs
@@ -7,14 +7,15 @@ import { renderReadme } from "../scripts/render-readme.mjs";
 const snapshot = JSON.parse(readFileSync(new URL("./fixtures/catalog.snapshot.json", import.meta.url), "utf8"));
 const model = buildCatalogModel(snapshot);
 const outside = (text) => text.replace(/<!-- CATALOG:START -->[\s\S]*?<!-- CATALOG:END -->/, "<!-- CATALOG:START --><!-- CATALOG:END -->");
+const normalize = (text) => text.replace(/\r\n/g, "\n");
 
 for (const language of ["zh", "en"]) test(`${language} README preserves its community template and renders the catalog`, () => {
   const actual = renderReadme(model, language);
   const template = readFileSync(new URL(`../docs/README.${language === "en" ? "en" : "zh"}.template.md`, import.meta.url), "utf8");
-  assert.equal(outside(actual), outside(template));
+  assert.equal(normalize(outside(actual)), normalize(outside(template)));
   assert.doesNotMatch(actual, /\r\n|162|156|Featured Agents/);
   assert.match(actual, new RegExp(`<!-- catalog-snapshot: ${snapshot.snapshot_id} -->`));
-  assert.match(actual, /\*\*16\*\* public assets|\*\*16\*\* 项公开资产/);
+  assert.match(actual, language === "en" ? /<strong>16<\/strong>\s*<br>\s*<sub>Assets<\/sub>/ : /<strong>16<\/strong>\s*<br>\s*<sub>资产<\/sub>/);
   assert.match(actual, /PandaAI|community/i);
   assert.deepEqual([...actual.matchAll(/\[([0-9]{2}) [^\]]+\]\(#cat-\1\)/g)].map((match) => match[1]), ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10"]);
   for (const stage of ["data-ingestion", "feature-engineering", "portfolio-construction", "monitoring", "orchestration"]) assert.match(actual, new RegExp(stage));

--- a/tests/verify-build-count.test.mjs
+++ b/tests/verify-build-count.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { build } from "../scripts/build.mjs";
+
+test("build verifies rendered HTML count cells for both README languages", () => {
+  const output = mkdtempSync(join(tmpdir(), "quantskills-build-count-"));
+  build(new URL("./fixtures/catalog.snapshot.json", import.meta.url), output);
+  const zh = readFileSync(join(output, "README.md"), "utf8");
+  const en = readFileSync(join(output, "README.en.md"), "utf8");
+  assert.match(zh, /<strong>16<\/strong>\s*<br>\s*<sub>资产<\/sub>/);
+  assert.match(en, /<strong>16<\/strong>\s*<br>\s*<sub>Assets<\/sub>/);
+});


### PR DESCRIPTION
## Summary\n- filter deprecated duplicate assets from the public site model\n- align build verification with the public projection\n- regenerate README and site data from Registry snapshot sha256:117387f24ed230521243f50541e0d1f8c10cd949848b4ba095c55222ba833c00\n\n## Verification\n- 
pm test (42 passed)\n- direct build and erifyBuild against the same Registry snapshot passed\n- generated site exposes 156 listed assets from a 158-asset full snapshot\n\nNo manual navigation list edits were made.